### PR TITLE
Fix for XP being reset back to old cap when converting at Paimos.

### DIFF
--- a/MMOCoreORB/bin/scripts/screenplays/village/convos/convohelpers/experience_converter.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/village/convos/convohelpers/experience_converter.lua
@@ -282,20 +282,12 @@ function ExperienceConverter:convertXpTransferCallback(pPlayer, pSui, eventIndex
 	local fsXpAmount = PlayerObject(pGhost):getExperience("fs_" .. conversionType)
 	local fsXpCap = PlayerObject(pGhost):getExperienceCap("fs_" .. conversionType)
 
-	if (fsXpCap > 0) then
-		if (fsXpCap <= fsXpAmount) then
-			CreatureObject(pPlayer):sendSystemMessage("@quest/force_sensitive/utils:convert_at_fs_skill_cap")
-			return
-		end
-
-		if (fsXpAmount + convertedXp > fsXpCap) then
-			convertedXp = fsXpCap - fsXpAmount;
-			xpToConvert = convertedXp * ratio;
-		end
-	else
+	-- << Modified block starts here >>
+	if (fsXpCap <= 0) then
 		CreatureObject(pPlayer):sendSystemMessage("@quest/force_sensitive/utils:convert_no_skill")
 		return
 	end
+	-- << Modified block ends here >>
 
 	if (convertedXp < 1) then
 		CreatureObject(pPlayer):sendSystemMessage("@quest/force_sensitive/utils:convert_allocate_more_xp")


### PR DESCRIPTION
Fix for XP being reset back to old cap when converting at Paimos.