### PR TITLE
Group bug fix, Iron spawns, and lootchance

### DIFF
--- a/MMOCoreORB/bin/scripts/managers/resource_manager.lua
+++ b/MMOCoreORB/bin/scripts/managers/resource_manager.lua
@@ -111,10 +111,10 @@ minimumpoolexcludes = jtlresources
   -- The random pool spawns a total number of resources equal to the size
 randompoolincludes = { {"metal", 32}, {"ore", 13}, {"fuel_petrochem_solid", 6}, {"radioactive", 4}, {"gemstone", 12}, {"gas", 16}, {"water", 2}, {"fuel_petrochem_liquid", 7}, {"petrochem_inert", 8} }
 randompoolexcludes = jtlresources..",iron,fiberplast"
-randompoolsize = 27
+randompoolsize = 33
 
   -- The fixed pool is a table of resources and occurrences. A resource will always be in spawn a number of times equal to it's occurrence. The function call inserts each JTL resource into the table with an occurrence of 1.
-fixedpoolincludes = InsertJtlIntoTable(jtlresources, { {"iron", 14} })
+fixedpoolincludes = InsertJtlIntoTable(jtlresources, { {"iron", 8} })
 fixedpoolexcludes = ""
 
   -- The native pool will have one of each of the items listed in the includes spawned on each planet at all times, but planet restricted.

--- a/MMOCoreORB/bin/scripts/mobile/dathomir/spiderclan_auspex.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dathomir/spiderclan_auspex.lua
@@ -33,7 +33,8 @@ spiderclan_auspex = Creature:new {
 		{
 			groups = {
 				{group = "spider_nightsister_tier_4", chance = 10000000}
-			}
+			},
+			lootChance = 7000000
 		}
 	},
 

--- a/MMOCoreORB/bin/scripts/mobile/dathomir/spiderclan_elder.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dathomir/spiderclan_elder.lua
@@ -33,7 +33,8 @@ spiderclan_elder = Creature:new {
 		{
 			groups = {
 				{group = "spider_nightsister_tier_5", chance = 10000000}
-			}
+			},
+			lootChance = 10000000
 		}
 	},
 

--- a/MMOCoreORB/bin/scripts/mobile/dathomir/spiderclan_protector.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dathomir/spiderclan_protector.lua
@@ -33,7 +33,8 @@ spiderclan_protector = Creature:new {
 		{
 			groups = {
 				{group = "spider_nightsister_tier_4", chance = 10000000}
-			}
+			},
+			lootChance = 7000000
 		}
 	},
 

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_assassin.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_assassin.lua
@@ -41,7 +41,7 @@ black_sun_assassin = Creature:new {
 				{group = "jetpack_base", chance = 50000},
 				{group = "wearables_common", chance = 500000},
 				{group = "wearables_uncommon", chance = 500000}
-			}
+			},
 			lootChance = 4000000, -- 40.00% total chance
 		}
 	},

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_guard.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_guard.lua
@@ -41,7 +41,7 @@ black_sun_guard = Creature:new {
 				{group = "jetpack_base", chance = 50000},
 				{group = "wearables_common", chance = 500000},
 				{group = "wearables_uncommon", chance = 500000}
-			}
+			},
 			lootChance = 4000000, -- 40.00% total chance
 		}
 	},

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_henchman.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_henchman.lua
@@ -41,7 +41,7 @@ black_sun_henchman = Creature:new {
 				{group = "jetpack_base", chance = 50000},
 				{group = "wearables_common", chance = 500000},
 				{group = "wearables_uncommon", chance = 500000}
-			}
+			},
 			lootChance = 3500000, -- 35.00% total chance
 		}
 	},

--- a/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_thug.lua
+++ b/MMOCoreORB/bin/scripts/mobile/dungeon/death_watch_bunker/black_sun_thug.lua
@@ -41,7 +41,7 @@ black_sun_thug = Creature:new {
 				{group = "jetpack_base", chance = 50000},
 				{group = "wearables_common", chance = 500000},
 				{group = "wearables_uncommon", chance = 500000}
-			}
+			},
 			lootChance = 3500000, -- 35.00% total chance
 		}
 	},

--- a/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/mission/MissionManagerImplementation.cpp
@@ -1893,7 +1893,7 @@ LairSpawn* MissionManagerImplementation::getRandomLairSpawn(CreatureObject* play
 	if (levelChoice > 0)
 		playerLevel = levelChoice;
 
-	if (player->isGrouped()) {
+/*	if (player->isGrouped()) {
 		bool includeFactionPets = faction != Factions::FACTIONNEUTRAL || ConfigManager::instance()->includeFactionPetsForMissionDifficulty();
 		Reference<GroupObject*> group = player->getGroup();
 
@@ -1901,7 +1901,7 @@ LairSpawn* MissionManagerImplementation::getRandomLairSpawn(CreatureObject* play
 			Locker locker(group);
 			playerLevel = group->getGroupLevel(includeFactionPets);
 		}
-	}
+	}*/
 
 	LairSpawn* lairSpawn = nullptr;
 


### PR DESCRIPTION
- Reduced Iron spawns down to 8 at all times instead of 14
- Added lootchance to high end Spiderclan
- Fixed lootchance on Black Suns
- Fixed bug preventing Groups from being able to grab max level missions