### PR TITLE
feat: Enhance structure management with lot refunding and house packing

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/housepackup/HousePackupManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/housepackup/HousePackupManager.cpp
@@ -1,0 +1,815 @@
+/*
+ * HousePackupManager.cpp
+ *
+ * Packs interior items into a versioned binary blob and restores them later.
+ * - Persists blobs to ./housepacks/ so server restarts don’t lose data.
+ * - Uses an in-memory table too (fast path within same uptime).
+ * - Supports hierarchical items (children inside containers).
+ */
+
+#include "server/zone/managers/housepackup/HousePackupManager.h"
+
+#include "engine/engine.h"
+
+#include "server/zone/Zone.h"
+#include "server/zone/managers/structure/StructureManager.h"
+#include "server/zone/managers/object/ObjectManager.h"
+
+#include "server/zone/objects/scene/SceneObject.h"
+#include "server/zone/objects/cell/CellObject.h"
+#include "server/zone/objects/building/BuildingObject.h"
+#include "server/zone/objects/tangible/TangibleObject.h"
+#include "server/zone/objects/creature/CreatureObject.h"
+
+#include "server/zone/objects/player/PlayerObject.h"
+#include "server/zone/objects/player/sessions/DestroyStructureSession.h"
+
+#include "templates/SharedObjectTemplate.h"
+// Add these two lines:
+#include "server/zone/managers/structure/StructureManager.h"
+#include "server/zone/objects/structure/StructureObject.h"
+
+// std file helpers
+#include <cstdio>      // std::FILE, std::fopen, std::fwrite, std::fread, std::fclose, std::remove, std::rename
+#include <sys/stat.h>  // ::stat
+#include <sys/types.h>
+#ifdef _WIN32
+  #include <direct.h>  // _mkdir
+#endif
+
+using namespace server::zone;
+using namespace server::zone::objects::scene;
+using namespace server::zone::objects::cell;
+using namespace server::zone::objects::building;
+using namespace server::zone::objects::tangible;
+using namespace server::zone::objects::creature;
+
+// -----------------------------
+// Persistent storage locations
+// -----------------------------
+
+// The server binary runs from /.../bin, so make this relative to that directory
+static const char* PACK_DIR = "housepacks";
+
+// Legacy location some forks used earlier. We only READ from here (fallback).
+static const char* LEGACY_PACK_DIR = "bin/housepacks";
+
+// deedOID -> blob (used by restore)
+static HashTable<uint64, Vector<uint8> > gDeedPayloads;
+
+// buildingOID -> blob (used during redeed window; then moved to deed)
+static HashTable<uint64, Vector<uint8> > gBuildingPayloads;
+
+// deedOID -> placeholder StructureObject OID
+static HashTable<uint64, uint64> gLotHoldByDeed;
+
+// -----------------------------
+// Small filesystem helpers
+// -----------------------------
+
+// Forward declarations for helpers used later in autoPackIfNeeded(...)
+static void listCells(BuildingObject* building, Vector< ManagedReference<CellObject*> >& cellsOut);
+static void listCellContents(CellObject* cell, Vector< ManagedReference<SceneObject*> >& out);
+
+static bool pathIsDir(const char* p) {
+    struct stat st;
+    if (::stat(p, &st) != 0) return false;
+#ifdef _WIN32
+    return (st.st_mode & _S_IFDIR) != 0;
+#else
+    return (st.st_mode & S_IFDIR) != 0;
+#endif
+}
+
+static bool ensurePackDir() {
+    if (pathIsDir(PACK_DIR)) return true;
+#ifdef _WIN32
+    int rc = ::_mkdir(PACK_DIR);
+#else
+    int rc = ::mkdir(PACK_DIR, 0755);
+#endif
+    // If it already exists, treat as success; otherwise rc==0 means created ok.
+    return rc == 0 || pathIsDir(PACK_DIR);
+}
+
+static String pathForBuilding(uint64 oid) {
+    String s(PACK_DIR); s += "/b-"; s += String::valueOf((int64)oid); s += ".bin";
+    return s;
+}
+static String pathForBuildingLegacy(uint64 oid) {
+    String s(LEGACY_PACK_DIR); s += "/b-"; s += String::valueOf((int64)oid); s += ".bin";
+    return s;
+}
+static String pathForDeed(uint64 oid) {
+    String s(PACK_DIR); s += "/d-"; s += String::valueOf((int64)oid); s += ".bin";
+    return s;
+}
+static String pathForDeedLegacy(uint64 oid) {
+    String s(LEGACY_PACK_DIR); s += "/d-"; s += String::valueOf((int64)oid); s += ".bin";
+    return s;
+}
+
+static bool writeBlobToFile(const String& path, const Vector<uint8>& blob) {
+    if (!ensurePackDir()) return false;
+
+    std::FILE* f = std::fopen(path.toCharArray(), "wb");
+    if (f == nullptr) return false;
+
+    // Write byte-by-byte because Vector<uint8> exposes .get() and .size() only.
+    size_t wrote = 0;
+    for (int i = 0; i < blob.size(); ++i) {
+        unsigned char c = blob.get(i);
+        wrote += std::fwrite(&c, 1, 1, f);
+    }
+
+    std::fclose(f);
+    return wrote == (size_t)blob.size();
+}
+
+static bool readBlobFromFile(const String& path, Vector<uint8>& out) {
+    std::FILE* f = std::fopen(path.toCharArray(), "rb");
+    if (f == nullptr) return false;
+
+    std::fseek(f, 0, SEEK_END);
+    long n = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    if (n <= 0) { std::fclose(f); return false; }
+
+    out.removeAll();
+    for (long i = 0; i < n; ++i) {
+        unsigned char c = 0;
+        size_t rd = std::fread(&c, 1, 1, f);
+        if (rd != 1) { std::fclose(f); return false; }
+        out.add((uint8)c);
+    }
+
+    std::fclose(f);
+    return true;
+}
+
+// Tiny helpers
+static bool fileExists(const String& p) {
+    struct stat st;
+    return ::stat(p.toCharArray(), &st) == 0 && (st.st_mode & S_IFREG);
+}
+static void removeFileIfExists(const String& p) {
+    // std::remove returns 0 on success, non-zero on failure; ignore result.
+    std::remove(p.toCharArray());
+}
+void HousePackupManager::sweepDanglingLotHolds(CreatureObject* player) {
+    if (!player) return;
+
+    ManagedReference<PlayerObject*> ghost = player->getPlayerObject();
+    if (ghost == nullptr) return;
+
+    const int n = ghost->getTotalOwnedStructureCount(); // your fork’s method
+    for (int i = 0; i < n; ++i) {
+        const uint64 oid = ghost->getOwnedStructure(i);
+        if (oid == 0) continue;
+
+        ManagedReference<SceneObject*> so = player->getZoneServer()->getObject(oid);
+        StructureObject* s = so.castTo<StructureObject*>();
+        if (!s) continue;
+
+        // We only destroy placeholders we created (tagged with our ObjVar).
+            // Destroying with refundLots=true returns the lots
+            StructureManager::instance()->destroyStructure(s, /*playEffect*/false, /*refundLots*/true);
+        }
+    }
+
+// -----------------------------
+// Presence checks / auto-pack guard
+// -----------------------------
+
+bool HousePackupManager::hasSavedPayloadForBuilding(uint64 buildingOID) const {
+    // RAM check
+    if (gBuildingPayloads.containsKey(buildingOID))
+        return true;
+
+    // Disk check (restart-safe file created by rememberPayloadForBuilding/packUpHouse)
+    const String bpath = pathForBuilding(buildingOID);
+    if (fileExists(bpath))
+        return true;
+
+    // (Optional) DB check — enable if you wired DB persistence too
+    // if (HousePackDB::hasBuilding(buildingOID)) return true;
+
+    return false;
+}
+// Add to HousePackupManager.cpp
+    bool HousePackupManager::hasLotPlaceholder(uint64 deedOID) const {
+        return gLotHoldByDeed.containsKey(deedOID);
+}
+
+bool HousePackupManager::autoPackIfNeeded(BuildingObject* building, CreatureObject* requester) {
+    if (building == nullptr || requester == nullptr) return false;
+
+    // If we already have a saved payload OR a lot placeholder, we're good.
+    if (hasSavedPayloadForBuilding(building->getObjectID()) || 
+        gLotHoldByDeed.containsKey(building->getDeedObjectID())) {
+        return true;
+    }
+    
+
+    // Scan interior for *any* items (excluding players/terminals).
+    Vector< ManagedReference<CellObject*> > cells;
+    listCells(building, cells);
+
+    bool hasItems = false;
+    for (int ci = 0; ci < cells.size() && !hasItems; ++ci) {
+        ManagedReference<CellObject*> cell = cells.get(ci);
+        if (cell == nullptr) continue;
+
+        Vector< ManagedReference<SceneObject*> > children;
+        listCellContents(cell, children);
+
+        for (int i = 0; i < children.size(); ++i) {
+            SceneObject* o = children.get(i);
+            if (o == nullptr) continue;
+            if (o->isCreatureObject() || o->isTerminal()) continue;
+            hasItems = true;
+            break;
+        }
+    }
+
+    if (!hasItems) {
+        // Empty house — safe to proceed
+        return true;
+    }
+
+    // There ARE items, but no saved payload; stop and warn clearly.
+    requester->sendSystemMessage(
+        "This structure still contains items. Use 'House Pack Up' at the terminal first, "
+        "then destroy/redeed. (Nothing was destroyed.)"
+    );
+    return false;
+}
+bool HousePackupManager::hasSavedPayloadForDeed(uint64 deedOID) const {
+    // Check RAM first
+    if (gDeedPayloads.containsKey(deedOID))
+        return true;
+        
+    // Check disk file
+    const String dpath = pathForDeed(deedOID);
+    if (fileExists(dpath))
+        return true;
+        
+    // Check legacy location
+    const String dpathLegacy = pathForDeedLegacy(deedOID);
+    if (fileExists(dpathLegacy))
+        return true;
+        
+    return false;
+}
+// Delete a file; OK if it doesn't exist.
+static void removeFile(const String& path) {
+    std::remove(path.toCharArray());
+}
+
+
+// -----------------------------
+// Container traversal helpers
+// -----------------------------
+
+static void listCells(BuildingObject* building, Vector< ManagedReference<CellObject*> >& cellsOut) {
+    cellsOut.removeAll();
+    if (!building) return;
+
+    Locker _lock(building);
+
+    const VectorMap<unsigned long long, ManagedReference<SceneObject*> >* cont = building->getContainerObjects();
+    if (!cont) return;
+
+    for (int i = 0; i < cont->size(); ++i) {
+        ManagedReference<SceneObject*> child = cont->elementAt(i).getValue();
+        if (child != nullptr && child->isCellObject()) {
+            ManagedReference<CellObject*> cell = cast<CellObject*>(child.get());
+            if (cell != nullptr) cellsOut.add(cell);
+        }
+    }
+}
+
+static void listCellContents(CellObject* cell, Vector< ManagedReference<SceneObject*> >& out) {
+    out.removeAll();
+    if (!cell) return;
+
+    Locker _lock(cell);
+
+    const VectorMap<unsigned long long, ManagedReference<SceneObject*> >* cont = cell->getContainerObjects();
+    if (!cont) return;
+
+    for (int i = 0; i < cont->size(); ++i) {
+        ManagedReference<SceneObject*> child = cont->elementAt(i).getValue();
+        if (child != nullptr) out.add(child);
+    }
+}
+
+
+// -----------------------------
+// Binary readers (big-endian)
+// -----------------------------
+
+static inline uint32 rU32(const Vector<uint8>& b, int& off) {
+    if ((int)b.size() - off < 4) return 0;
+    uint32 v = ((uint32)b.get(off) << 24) |
+               ((uint32)b.get(off + 1) << 16) |
+               ((uint32)b.get(off + 2) << 8) |
+               ((uint32)b.get(off + 3));
+    off += 4;
+    return v;
+}
+
+static inline uint16 rU16(const Vector<uint8>& b, int& off) {
+    if ((int)b.size() - off < 2) return 0;
+    uint16 v = ((uint16)b.get(off) << 8) | ((uint16)b.get(off + 1));
+    off += 2;
+    return v;
+}
+
+static inline float rF32(const Vector<uint8>& b, int& off) {
+    if ((int)b.size() - off < 4) return 0.0f;
+    uint32 u = rU32(b, off);
+    union { uint32 u; float f; } cvt;
+    cvt.u = u;
+    return cvt.f;
+}
+
+
+// -----------------------------
+// Exposed helpers (header API)
+// -----------------------------
+
+void HousePackupManager::rememberPayloadForBuilding(uint64 buildingOID, const Vector<uint8>& blob) {
+	// Keep it in RAM for same-process flow.
+	gBuildingPayloads.put(buildingOID, blob);
+
+	// Also persist so we can survive server restarts.
+	const String path = pathForBuilding(buildingOID);
+	if (!writeBlobToFile(path, blob)) {
+		// 'warning' comes from Logger base; this class derives from Logger.
+		warning("HousePackup: failed to write building payload to " + path);
+	}
+}
+
+void HousePackupManager::attachPayloadToDeedFromBuilding(uint64 buildingOID, uint64 deedOID) {
+    Vector<uint8> blob;
+
+    // Prefer in-memory copy first
+    if (gBuildingPayloads.containsKey(buildingOID)) {
+        blob = gBuildingPayloads.get(buildingOID);
+        gBuildingPayloads.remove(buildingOID);
+    } else {
+        // Fallback: read from disk file created at pack time
+        const String bpath = pathForBuilding(buildingOID);
+        if (!readBlobFromFile(bpath, blob)) {
+            warning("HousePackup: no payload found for building OID " + String::valueOf((int64)buildingOID) +
+                    " (neither memory nor " + bpath + ")");
+            return;
+        }
+        // Clean up the building file once we’ve loaded it
+        removeFile(bpath);
+    }
+
+    // Put in memory under deed OID for immediate restore
+    gDeedPayloads.put(deedOID, blob);
+
+    // Persist under deed OID so it survives restarts (until placement restores it)
+    const String dpath = pathForDeed(deedOID);
+    bool wrote = writeBlobToFile(dpath, blob);
+
+    // Optional: if you have the placer CreatureObject around, send them a message here.
+    // (If you don't, this is still fine; the restore step will also log.)
+    info("HousePackup: moved payload to deed OID " + String::valueOf((int64)deedOID) +
+         " and wrote " + String::valueOf((int)blob.size()) + " bytes to " + dpath +
+         (wrote ? " [OK]" : " [FAILED]"));
+}
+// ====== Top of HousePackupManager.cpp (near your other statics) ======
+static HashTable<uint64, uint64> gDeedByHold;    // holdOID -> deedOID  (reverse)
+
+// --- mapping helpers (definitions) ---
+void HousePackupManager::recordLotHold(uint64 deedOID, uint64 holdStructureOID) {
+    gLotHoldByDeed.put(deedOID, holdStructureOID);
+}
+
+uint64 HousePackupManager::takeLotHold(uint64 deedOID) {
+    if (!gLotHoldByDeed.containsKey(deedOID))
+        return 0;
+    uint64 hold = gLotHoldByDeed.get(deedOID);
+    gLotHoldByDeed.remove(deedOID);
+    return hold;
+}
+
+uint64 HousePackupManager::createLotsPlaceholderFor(
+    CreatureObject* owner,
+    int lotSize,
+    uint64 deedOID,
+    const String& structureTemplatePath
+) {
+    if (!owner || deedOID == 0) return 0;
+
+    // Don't create a physical structure - just record that this deed "holds" lots
+    // The lots are already consumed by the existing building being packed
+    recordLotHold(deedOID, deedOID); // Use deed OID as the "placeholder" ID
+    
+    if (owner) {
+        owner->sendSystemMessage("Lot hold recorded for packed house (no additional lot consumption).");
+    }
+    
+    return deedOID;
+}
+
+void HousePackupManager::releaseLotsPlaceholder(uint64 deedOID, CreatureObject* owner) {
+    uint64 holdOID = takeLotHold(deedOID);
+    if (holdOID == 0) return; // No placeholder was recorded
+    
+    // Since we didn't create a physical structure, just remove the mapping
+    if (owner) {
+        owner->sendSystemMessage("Released lot hold for packed deed - lots now available for new structure.");
+    }
+    
+    // No structure to destroy since we only recorded the mapping
+}
+// -----------------------------
+// Recursive collector
+// -----------------------------
+
+static void collectDeep(
+    SceneObject* obj,
+    uint16 cellIdx,
+    uint16 parentIdx,
+    Vector< ManagedReference<SceneObject*> >& ordered,
+    Vector<uint16>& orderedCellIndex,
+    Vector<uint16>& orderedParentIndex
+) {
+    if (!obj) return;
+    if (obj->isCreatureObject() || obj->isTerminal()) return; // skip players/terminals
+
+    uint16 myIndex = (uint16)ordered.size();
+    ordered.add(obj);
+    orderedCellIndex.add(cellIdx);
+    orderedParentIndex.add(parentIdx);
+
+    const VectorMap<unsigned long long, ManagedReference<SceneObject*> >* cmap = obj->getContainerObjects();
+    if (cmap != nullptr) {
+        for (int i = 0; i < cmap->size(); ++i) {
+            ManagedReference<SceneObject*> child = cmap->elementAt(i).getValue();
+            if (child == nullptr) continue;
+            collectDeep(child, cellIdx, myIndex, ordered, orderedCellIndex, orderedParentIndex);
+        }
+    }
+}
+
+
+// -----------------------------
+// Pack (called from terminal)
+// -----------------------------
+
+bool HousePackupManager::packUpHouse(BuildingObject* building, CreatureObject* requester) {
+    if (building == nullptr || requester == nullptr)
+        return false;
+
+    // Collect all cells
+    Vector< ManagedReference<CellObject*> > cells;
+    listCells(building, cells);
+
+    // Build payload blob v2: [u8 ver=2][u32 count][per-item...]
+    // Per item v2: u32 tpl, u16 cellIndex, u16 parentIndex(0xFFFF=no parent),
+    //              f32 px,py,pz, f32 qw,qx,qy,qz
+    Vector<uint8> blob;
+    blob.add((uint8)2); // version 2
+
+    // Pre-order list so we know parent indices
+    Vector< ManagedReference<SceneObject*> > ordered;
+    Vector<uint16> orderedCellIndex;
+    Vector<uint16> orderedParentIndex;
+
+    // Seed with top-level objects in each cell
+    for (int ci = 0; ci < cells.size(); ++ci) {
+        ManagedReference<CellObject*> cell = cells.get(ci);
+        if (!cell) continue;
+
+        Vector< ManagedReference<SceneObject*> > contents;
+        listCellContents(cell, contents);
+
+        for (int i = 0; i < contents.size(); ++i) {
+            collectDeep(contents.get(i), (uint16)ci, (uint16)0xFFFF,
+                        ordered, orderedCellIndex, orderedParentIndex);
+        }
+    }
+
+    uint32 count = (uint32)ordered.size();
+
+    requester->sendSystemMessage(
+        "Pack scan: " + String::valueOf((int)cells.size()) + " cells, " +
+        String::valueOf((int)count) + " candidate items."
+    );
+
+    // write count (big-endian u32)
+    blob.add((uint8)((count >> 24) & 0xFF));
+    blob.add((uint8)((count >> 16) & 0xFF));
+    blob.add((uint8)((count >>  8) & 0xFF));
+    blob.add((uint8)((count      ) & 0xFF));
+
+    // helper: write f32 as big-endian
+    auto wf32 = [&](float f) {
+        union { float f; uint32 u; } u; u.f = f;
+        blob.add((uint8)((u.u >> 24) & 0xFF));
+        blob.add((uint8)((u.u >> 16) & 0xFF));
+        blob.add((uint8)((u.u >>  8) & 0xFF));
+        blob.add((uint8)((u.u      ) & 0xFF));
+    };
+
+    // write per-item
+    for (uint32 idx = 0; idx < count; ++idx) {
+        SceneObject* obj = ordered.get(idx);
+        uint16 cellIdx   = orderedCellIndex.get(idx);
+        uint16 parentIdx = orderedParentIndex.get(idx);
+        uint32 tpl       = obj->getServerObjectCRC();
+
+        // tpl u32
+        blob.add((uint8)((tpl >> 24) & 0xFF));
+        blob.add((uint8)((tpl >> 16) & 0xFF));
+        blob.add((uint8)((tpl >>  8) & 0xFF));
+        blob.add((uint8)((tpl      ) & 0xFF));
+
+        // cellIndex u16
+        blob.add((uint8)((cellIdx >> 8) & 0xFF));
+        blob.add((uint8)((cellIdx     ) & 0xFF));
+
+        // parentIndex u16 (0xFFFF = top-level)
+        blob.add((uint8)((parentIdx >> 8) & 0xFF));
+        blob.add((uint8)((parentIdx     ) & 0xFF));
+
+        // positions/orientations: only meaningful for top-level items
+        if (parentIdx == (uint16)0xFFFF) {
+            // Store current object transform. In this fork Z is up.
+            wf32(obj->getPositionX());
+            wf32(obj->getPositionY());
+            wf32(obj->getPositionZ());
+            wf32(obj->getDirectionW());
+            wf32(obj->getDirectionX());
+            wf32(obj->getDirectionY());
+            wf32(obj->getDirectionZ());
+        } else {
+            // Children will be inserted into their parent's container; no transform needed.
+            wf32(0.f); wf32(0.f); wf32(0.f);
+            wf32(1.f); wf32(0.f); wf32(0.f); wf32(0.f);
+        }
+    }
+
+    // Remember payload (RAM) and also persist to disk so it survives restarts.
+    rememberPayloadForBuilding(building->getObjectID(), blob);
+
+    const String p = pathForBuilding(building->getObjectID());
+    bool wrote = writeBlobToFile(p, blob);
+
+    // Tell the player exactly what happened so we can verify paths/sizes easily.
+    requester->sendSystemMessage(
+        String("Pack: wrote ") + String::valueOf((int)blob.size()) + " bytes to " + p +
+        (wrote ? String(" [OK]") : String(" [FAILED]"))
+    );
+
+    // Create lot placeholder to hold the lots during pack-up
+    // This prevents lot duplication when the structure is redeeded
+    uint64 deedOID = building->getDeedObjectID();
+    if (deedOID != 0 && !gLotHoldByDeed.containsKey(deedOID)) {
+        SharedStructureObjectTemplate* tmpl = dynamic_cast<SharedStructureObjectTemplate*>(building->getObjectTemplate());
+        String templatePath = tmpl ? tmpl->getFullTemplateString() : "";
+        int lotSize = tmpl ? tmpl->getLotSize() : building->getLotSize();
+        
+        uint64 placeholderOID = createLotsPlaceholderFor(requester, lotSize, deedOID, templatePath);
+if (placeholderOID != 0) {
+    requester->sendSystemMessage("Created lot placeholder OID: " + String::valueOf((int64)placeholderOID) + 
+                                " for " + String::valueOf(lotSize) + " lots");
+    // Check player's lots after placeholder creation
+    ManagedReference<PlayerObject*> ghost = requester->getPlayerObject();
+    if (ghost) {
+        requester->sendSystemMessage("Player lots after placeholder: " + String::valueOf(ghost->getLotsRemaining()));
+    }
+} else {
+    warning("Failed to create lot placeholder for deed OID " + String::valueOf((int64)deedOID));
+}
+    }
+
+    // Now empty the interior so the core will allow redeed/destruction.
+    if (building && building->getZone() != nullptr) {
+        Vector< ManagedReference<CellObject*> > cellsToDelete;
+        listCells(building, cellsToDelete);
+
+        for (int ci = 0; ci < cellsToDelete.size(); ++ci) {
+            ManagedReference<CellObject*> cell = cellsToDelete.get(ci);
+            if (cell == nullptr) continue;
+
+            Vector< ManagedReference<SceneObject*> > children;
+            listCellContents(cell, children);
+
+            for (int i = 0; i < children.size(); ++i) {
+                ManagedReference<SceneObject*> obj = children.get(i);
+                if (obj == nullptr) continue;
+
+                // DO NOT delete players or terminals (e.g., the structure terminal)
+                if (obj->isCreatureObject() || obj->isTerminal())
+                    continue;
+
+                // Delete everything else we packed
+                obj->destroyObjectFromWorld(true);
+                obj->destroyObjectFromDatabase(true);
+            }
+        }
+    }
+
+    requester->sendSystemMessage(
+        "Packed " + String::valueOf(count) +
+        " items. Use 'Destroy Structure' to reclaim the deed. "
+        "When the deed is granted, contents will be attached automatically."
+    );
+
+    return true;
+}
+
+bool HousePackupManager::restoreFromDeed(BuildingObject* newBuilding, TangibleObject* deed, CreatureObject* placer) {
+    if (!newBuilding || !deed) return false;
+
+    const uint64 deedOID = deed->getObjectID();
+    Vector<uint8> blob;
+
+    // -------- STEP 1: Try RAM by deed OID --------
+    if (gDeedPayloads.containsKey(deedOID)) {
+        blob = gDeedPayloads.get(deedOID);
+
+    } else {
+        // -------- STEP 2: Try deed files (current, then legacy) --------
+        const String dpath = pathForDeed(deedOID);
+        const String dpathLegacy = pathForDeedLegacy(deedOID);
+
+        if (!readBlobFromFile(dpath, blob)) {
+            (void)readBlobFromFile(dpathLegacy, blob); // try legacy; ignore return here
+        }
+
+        // -------- STEP 3: If still not found, try building OID (RAM/disk/legacy) and MIGRATE --------
+        if (blob.isEmpty()) {
+            const uint64 bOID = newBuilding->getObjectID();
+
+            // 3a) RAM by building
+            if (gBuildingPayloads.containsKey(bOID)) {
+                blob = gBuildingPayloads.get(bOID);
+                gBuildingPayloads.remove(bOID);
+
+            } else {
+                // 3b) Disk by building (current, then legacy)
+                const String bpath = pathForBuilding(bOID);
+                const String bpathLegacy = pathForBuildingLegacy(bOID);
+
+                if (!readBlobFromFile(bpath, blob)) {
+                    (void)readBlobFromFile(bpathLegacy, blob);
+                    if (!blob.isEmpty()) removeFile(bpathLegacy);
+                }
+                if (!blob.isEmpty()) removeFile(bpath);
+            }
+
+            // If we recovered from a building payload, migrate it into deed RAM+disk for future
+            if (!blob.isEmpty()) {
+                gDeedPayloads.put(deedOID, blob);
+                (void)writeBlobToFile(pathForDeed(deedOID), blob);
+            }
+        }
+    }
+
+    // Nothing found anywhere
+    if (blob.isEmpty()) {
+        if (placer) placer->sendSystemMessage("No packed contents found for this deed.");
+        return false;
+    }
+
+    // -------- Readers (big-endian) --------
+    auto rU8   = [&](int& o)->uint8  { return blob.get(o++); };
+    auto rU16B = [&](int& o)->uint16 { uint16 v = ((uint16)blob.get(o)<<8) | ((uint16)blob.get(o+1)); o+=2; return v; };
+    auto rU32B = [&](int& o)->uint32 { uint32 v = ((uint32)blob.get(o)<<24)|((uint32)blob.get(o+1)<<16)|((uint32)blob.get(o+2)<<8)|((uint32)blob.get(o+3)); o+=4; return v; };
+    auto rF32B = [&](int& o)->float  { union { uint32 u; float f; } u; u.u = rU32B(o); return u.f; };
+
+    int off = 0;
+    if ((int)blob.size() < 5) {
+        if (placer) placer->sendSystemMessage("Packed data is corrupted.");
+        gDeedPayloads.remove(deedOID);
+        removeFile(pathForDeed(deedOID));
+        removeFile(pathForDeedLegacy(deedOID));
+        return false;
+    }
+
+    uint8  ver   = rU8(off);            // 1 = flat, 2 = hierarchical
+    uint32 count = rU32B(off);
+
+    // -------- Collect new building cells --------
+    Vector< ManagedReference<CellObject*> > cells;
+    listCells(newBuilding, cells);
+    if (cells.isEmpty()) {
+        gDeedPayloads.remove(deedOID);
+        removeFile(pathForDeed(deedOID));
+        removeFile(pathForDeedLegacy(deedOID));
+        if (placer) placer->sendSystemMessage("Restore aborted: building has no cells.");
+        return false;
+    }
+
+    // Keep created objects so children can attach to parents
+    Vector< ManagedReference<SceneObject*> > created;
+    Vector<uint16> parentIndex;  // 0xFFFF = no parent (top-level)
+    Vector<uint16> cellIndex;
+
+    uint32 restored = 0, failedCreate = 0, failedTransfer = 0;
+
+    // -------- First pass: create objects; place top-level only --------
+    for (uint32 k = 0; k < count; ++k) {
+        // v1: u32 tpl, u16 cell, 7*f32; v2 adds u16 parent -> 34 vs 36 bytes
+        int need = (ver >= 2 ? 4+2+2 + 7*4 : 4+2 + 7*4);
+        if (((int)blob.size() - off) < need) break;
+
+        uint32 tpl   = rU32B(off);
+        uint16 cIdx  = rU16B(off);
+        uint16 pIdx  = (ver >= 2) ? rU16B(off) : (uint16)0xFFFF;
+
+        float px = rF32B(off), py = rF32B(off), pz = rF32B(off);
+        float qw = rF32B(off), qx = rF32B(off), qy = rF32B(off), qz = rF32B(off);
+
+        ManagedReference<CellObject*> cell =
+            (cIdx < (uint16)cells.size()) ? cells.get((int)cIdx) : cells.get(0);
+
+        // Use persistence=1 so restored items survive restarts
+        SceneObject* raw = ObjectManager::instance()->createObject(tpl, /*persistenceLevel*/1, /*db*/"sceneobjects");
+        if (!raw) raw = ObjectManager::instance()->createObject(tpl, 1, "objects");
+        if (!raw) raw = ObjectManager::instance()->createObject(tpl, 1, "object");
+
+        created.add(raw);
+        parentIndex.add(pIdx);
+        cellIndex.add(cIdx);
+
+        if (!raw || !cell) { failedCreate += (!raw); failedTransfer += (!!raw && !cell); continue; }
+
+        if (pIdx == (uint16)0xFFFF) {
+            // Top-level placement: positions were stored with Z up — place as-is.
+            float z = pz;
+
+            // Gentle clamp above floor to prevent sinking on some shells.
+            float floorZ = cell->getPositionZ();
+            if (z < floorZ + 0.01f) z = floorZ + 0.02f;
+
+            raw->setPosition(px, /*world Y*/ py, /*world Z*/ z);
+            raw->setDirection(qw, qx, qy, qz);
+
+            bool ok = cell->transferObject(raw, /*containmentType*/-1, /*notifyClient*/false, /*allowOverflow*/false, /*notifyRoot*/true);
+            if (!ok) ok = cell->transferObject(raw, 0, false, false, true);
+            if (!ok) {
+                failedTransfer++;
+                raw->destroyObjectFromWorld(true);
+                raw->destroyObjectFromDatabase(true);
+                created.set(k, nullptr);
+            } else {
+                // tiny lift to avoid z-fighting
+                raw->setPosition(raw->getPositionX(), raw->getPositionY(), raw->getPositionZ() + 0.02f);
+                restored++;
+            }
+        }
+        // Children attached in second pass.
+    }
+
+    // -------- Second pass: attach children into their parent containers --------
+    if (ver >= 2) {
+        for (uint32 k = 0; k < count; ++k) {
+            uint16 pIdx = parentIndex.get(k);
+            if (pIdx == (uint16)0xFFFF) continue;
+
+            SceneObject* child  = created.get(k);
+            SceneObject* parent = (pIdx < created.size()) ? created.get(pIdx) : nullptr;
+            if (!child || !parent) continue;
+
+            bool ok = parent->transferObject(child, /*containmentType*/-1, /*notifyClient*/false, /*allowOverflow*/false, /*notifyRoot*/true);
+            if (!ok) ok = parent->transferObject(child, 0, false, false, true);
+            if (!ok) {
+                failedTransfer++;
+                child->destroyObjectFromWorld(true);
+                child->destroyObjectFromDatabase(true);
+                created.set(k, nullptr);
+            } else {
+                restored++;
+            }
+        }
+    }
+
+    // -------- Cleanup: don’t double-restore --------
+    gDeedPayloads.remove(deedOID);
+    removeFile(pathForDeed(deedOID));
+    removeFile(pathForDeedLegacy(deedOID));
+
+    if (placer) {
+        placer->sendSystemMessage(
+            "Restore complete: " +
+            String::valueOf(restored) + " restored, " +
+            String::valueOf(failedCreate) + " create fails, " +
+            String::valueOf(failedTransfer) + " transfer fails."
+        );
+    }
+    // Free the lot placeholder now that the house has been placed and contents restored.
+    releaseLotsPlaceholder(deedOID);
+
+
+    return restored > 0;
+}

--- a/MMOCoreORB/src/server/zone/managers/housepackup/HousePackupManager.h
+++ b/MMOCoreORB/src/server/zone/managers/housepackup/HousePackupManager.h
@@ -1,0 +1,70 @@
+// HousePackupManager.h
+#pragma once
+
+#include "engine/engine.h"           // String, Logger, Object, etc.
+#include "server/zone/ZoneServer.h"  // ZoneServer
+
+// Forward declarations to avoid polluting headers with 'using namespace'
+namespace server { namespace zone {
+    class ZoneServer;
+    namespace objects {
+        namespace building { class BuildingObject; }
+        namespace creature { class CreatureObject; }
+        namespace tangible { class TangibleObject; }
+    }
+}}
+
+// Convenience aliases (only for this header’s scope)
+namespace sz   = server::zone;
+namespace bld  = server::zone::objects::building;
+namespace crt  = server::zone::objects::creature;
+namespace tang = server::zone::objects::tangible;
+
+class HousePackupManager : public Logger, public Object, public Singleton<HousePackupManager> {
+public:
+    HousePackupManager() { setLoggingName("HousePackupManager"); }
+    inline void initialize(sz::ZoneServer* zs) { zoneServer = zs; }
+
+    // Main entry points
+    bool packUpHouse(bld::BuildingObject* building, crt::CreatureObject* requester);
+    bool restoreFromDeed(bld::BuildingObject* building, tang::TangibleObject* deed, crt::CreatureObject* placer);
+    // Add to HousePackupManager.h
+    bool hasLotPlaceholder(uint64 deedOID) const;
+
+    // Payload wiring
+    void attachPayloadToDeedFromBuilding(uint64 buildingOID, uint64 deedOID);
+    void rememberPayloadForDeed(uint64 deedOID, const Vector<uint8>& blob);
+    void rememberPayloadForBuilding(uint64 buildingOID, const Vector<uint8>& blob);
+    bool takePayloadForBuilding(uint64 buildingOID, Vector<uint8>& out);
+
+    // Optional player-pending cache
+    void rememberPendingForPlayer(uint64 playerOID, const Vector<uint8>& blob);
+    bool takePendingForPlayer(uint64 playerOID, Vector<uint8>& out);
+    void clearPendingForPlayer(uint64 playerOID);
+
+    // Safety checks
+    bool hasSavedPayloadForBuilding(uint64 buildingOID) const;
+    bool autoPackIfNeeded(bld::BuildingObject* building, crt::CreatureObject* requester);
+    bool hasSavedPayloadForDeed(uint64 deedOID) const;
+
+  // Lot-hold mapping (deed → placeholder structure OID)
+void recordLotHold(uint64 deedOID, uint64 holdStructureOID);
+uint64 takeLotHold(uint64 deedOID); // returns 0 if none
+
+// Create a temporary "placeholder" structure to hold lots during pack-up.
+uint64 createLotsPlaceholderFor(
+    server::zone::objects::creature::CreatureObject* owner,
+    int lotSize,
+    uint64 deedOID,
+    const String& structureTemplatePath);
+
+// Remove & destroy a previously created lots placeholder (if present).
+void releaseLotsPlaceholder(uint64 deedOID,
+    server::zone::objects::creature::CreatureObject* owner = nullptr);
+
+// Clean up any dangling placeholders on this player
+void sweepDanglingLotHolds(crt::CreatureObject* player);
+
+private:
+    sz::ZoneServer* zoneServer = nullptr;
+};

--- a/MMOCoreORB/src/server/zone/managers/structure/StructureManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/structure/StructureManager.cpp
@@ -50,6 +50,7 @@
 #include "server/zone/objects/player/FactionStatus.h"
 #include "templates/building/CampStructureTemplate.h"
 #include "templates/customization/CustomizationIdManager.h"
+#include "server/zone/managers/housepackup/HousePackupManager.h" // add at top of StructureManager.cpp
 
 namespace StorageManagerNamespace {
 int indexCallback(DB* secondary, const DBT* key, const DBT* data, DBT* result) {
@@ -266,213 +267,200 @@ int StructureManager::getStructureFootprint(SharedStructureObjectTemplate* objec
 
 	return 0;
 }
+  int StructureManager::placeStructureFromDeed(CreatureObject* creature, StructureDeed* deed, float x, float y, int angle) {
+    ManagedReference<Zone*> zone = creature->getZone();
 
-int StructureManager::placeStructureFromDeed(CreatureObject* creature, StructureDeed* deed, float x, float y, int angle) {
-	ManagedReference<Zone*> zone = creature->getZone();
+    // Already placing a structure?
+    if (zone == nullptr || creature->containsActiveSession(SessionFacadeType::PLACESTRUCTURE)) {
+        return 1;
+    }
 
-	// Already placing a structure?
-	if (zone == nullptr || creature->containsActiveSession(SessionFacadeType::PLACESTRUCTURE))
-		return 1;
+    String serverTemplatePath = deed->getGeneratedObjectTemplate();
 
-	String serverTemplatePath = deed->getGeneratedObjectTemplate();
+    // Check deed faction, player faction and status to make sure they are allowed to place faction deeds (bases)
+    if (deed->getFaction() != Factions::FACTIONNEUTRAL) {
+        if (creature->getFaction() == Factions::FACTIONNEUTRAL || creature->getFactionStatus() == FactionStatus::ONLEAVE) {
+            StringIdChatParameter message("@faction_perk:prose_not_neutral");
+            message.setTT(deed->getDisplayedName());
+            creature->sendSystemMessage(message);
+            return 1;
+        }
 
-	// Check deed faction, player faction and status to make sure they are allowed to place a faction deeds (bases)
-	if (deed->getFaction() != Factions::FACTIONNEUTRAL) {
-		if (creature->getFaction() == Factions::FACTIONNEUTRAL || creature->getFactionStatus() == FactionStatus::ONLEAVE) {
-			StringIdChatParameter message("@faction_perk:prose_not_neutral"); // You cannot use %TT if you are neutral or on leave.
-			message.setTT(deed->getDisplayedName());
+        if (deed->getFaction() != creature->getFaction()) {
+            UnicodeString deedFaction = "";
+            if (deed->isRebel()) deedFaction = "Rebel";
+            else if (deed->isImperial()) deedFaction = "Imperial";
 
-			creature->sendSystemMessage(message);
-			return 1;
-		}
+            StringIdChatParameter message("@faction_perk:prose_wrong_faction");
+            message.setTT(deed->getDisplayedName());
+            message.setTO(deedFaction);
+            creature->sendSystemMessage(message);
+            return 1;
+        }
+    }
 
-		if (deed->getFaction() != creature->getFaction()) {
-			UnicodeString deedFaction = "";
+    ManagedReference<PlanetManager*> planetManager = zone->getPlanetManager();
 
-			if (deed->isRebel()) {
-				deedFaction = "Rebel";
-			} else if (deed->isImperial()) {
-				deedFaction = "Imperial";
-			}
+    Reference<SharedStructureObjectTemplate*> serverTemplate =
+        dynamic_cast<SharedStructureObjectTemplate*>(templateManager->getTemplate(serverTemplatePath.hashCode()));
 
-			StringIdChatParameter message("@faction_perk:prose_wrong_faction"); // You must be declared to %TO faction to use %TT.
-			message.setTT(deed->getDisplayedName());
-			message.setTO(deedFaction);
+    // Check to see if this zone allows this structure.
+    if (serverTemplate == nullptr || !serverTemplate->isAllowedZone(zone->getZoneName())) {
+        creature->sendSystemMessage("@player_structure:wrong_planet");
+        return 1;
+    }
 
-			creature->sendSystemMessage(message);
-			return 1;
-		}
-	}
+    if (!planetManager->isBuildingPermittedAt(x, y, creature)) {
+        creature->sendSystemMessage("@player_structure:not_permitted");
+        return 1;
+    }
 
-	ManagedReference<PlanetManager*> planetManager = zone->getPlanetManager();
+    SortedVector<ManagedReference<ActiveArea*>> objects;
+    zone->getInRangeActiveAreas(x, 0, y, &objects, true);
 
-	Reference<SharedStructureObjectTemplate*> serverTemplate = dynamic_cast<SharedStructureObjectTemplate*>(templateManager->getTemplate(serverTemplatePath.hashCode()));
+    ManagedReference<CityRegion*> city;
+    for (int i = 0; i < objects.size(); ++i) {
+        ActiveArea* area = objects.get(i).get();
+        if (!area->isRegion()) continue;
+        city = dynamic_cast<Region*>(area)->getCityRegion().get();
+        if (city != nullptr) break;
+    }
 
-	// Check to see if this zone allows this structure.
-	if (serverTemplate == nullptr || !serverTemplate->isAllowedZone(zone->getZoneName())) {
-		creature->sendSystemMessage("@player_structure:wrong_planet"); // That deed cannot be used on this planet.
-		return 1;
-	}
+    if (city != nullptr && city->isClientRegion()) {
+        creature->sendSystemMessage("@player_structure:not_permitted");
+        return 1;
+    }
 
-	if (!planetManager->isBuildingPermittedAt(x, y, creature)) {
-		creature->sendSystemMessage("@player_structure:not_permitted"); // Building is not permitted here.
-		return 1;
-	}
+    SortedVector<ManagedReference<TreeEntry*> > inRangeObjects;
+    zone->getInRangeObjects(x, 0, y, 128, &inRangeObjects, true, false);
 
-	SortedVector<ManagedReference<ActiveArea*>> objects;
-	zone->getInRangeActiveAreas(x, 0, y, &objects, true);
+    float placingFootprintLength0 = 0, placingFootprintWidth0 = 0, placingFootprintLength1 = 0, placingFootprintWidth1 = 0;
 
-	ManagedReference<CityRegion*> city;
+    if (!getStructureFootprint(serverTemplate, angle, placingFootprintLength0, placingFootprintWidth0, placingFootprintLength1, placingFootprintWidth1)) {
+        float x0 = x + placingFootprintWidth0;
+        float y0 = y + placingFootprintLength0;
+        float x1 = x + placingFootprintWidth1;
+        float y1 = y + placingFootprintLength1;
 
-	for (int i = 0; i < objects.size(); ++i) {
-		ActiveArea* area = objects.get(i).get();
+        BoundaryRectangle placingFootprint(x0, y0, x1, y1);
 
-		if (!area->isRegion())
-			continue;
+        debug() << "placing center x:" << x << " y:" << y << "placingFootprint x0:" << x0 << " y0:" << y0 << " x1:" << x1 << " y1:" << y1;
 
-		city = dynamic_cast<Region*>(area)->getCityRegion().get();
+        for (int i = 0; i < inRangeObjects.size(); ++i) {
+            SceneObject* scene = inRangeObjects.get(i).castTo<SceneObject*>();
+            if (scene == nullptr) continue;
 
-		if (city != nullptr)
-			break;
-	}
+            float l0 = -5, w0 = -5, l1 = 5, w1 = 5;
 
-	if (city != nullptr && city->isClientRegion()) {
-		creature->sendSystemMessage("@player_structure:not_permitted"); // Building is not permitted here.
-		return 1;
-	}
+            if (getStructureFootprint(dynamic_cast<SharedStructureObjectTemplate*>(scene->getObjectTemplate()),
+                                      scene->getDirectionAngle(), l0, w0, l1, w1))
+                continue;
 
-	SortedVector<ManagedReference<TreeEntry*> > inRangeObjects;
-	zone->getInRangeObjects(x, 0, y, 128, &inRangeObjects, true, false);
+            float xx0 = scene->getPositionX() + (w0 + 0.1f);
+            float yy0 = scene->getPositionY() + (l0 + 0.1f);
+            float xx1 = scene->getPositionX() + (w1 - 0.1f);
+            float yy1 = scene->getPositionY() + (l1 - 0.1f);
 
-	float placingFootprintLength0 = 0, placingFootprintWidth0 = 0, placingFootprintLength1 = 0, placingFootprintWidth1 = 0;
+            BoundaryRectangle rect(xx0, yy0, xx1, yy1);
+            debug() << "existing footprint xx0:" << xx0 << " yy0:" << yy0 << " xx1:" << xx1 << " yy1:" << yy1;
 
-	if (!getStructureFootprint(serverTemplate, angle, placingFootprintLength0, placingFootprintWidth0, placingFootprintLength1, placingFootprintWidth1)) {
-		float x0 = x + placingFootprintWidth0;
-		float y0 = y + placingFootprintLength0;
-		float x1 = x + placingFootprintWidth1;
-		float y1 = y + placingFootprintLength1;
+            if (rect.containsPoint(x0, y0) || rect.containsPoint(x0, y1) || rect.containsPoint(x1, y0) || rect.containsPoint(x1, y1)) {
+                debug() << "existing footprint contains placing point";
+                creature->sendSystemMessage("@player_structure:no_room");
+                return 1;
+            }
 
-		BoundaryRectangle placingFootprint(x0, y0, x1, y1);
+            if (placingFootprint.containsPoint(xx0, yy0) || placingFootprint.containsPoint(xx0, yy1) ||
+                placingFootprint.containsPoint(xx1, yy0) || placingFootprint.containsPoint(xx1, yy1) ||
+                (xx0 == x0 && yy0 == y0 && xx1 == x1 && yy1 == y1)) {
+                debug() << "placing footprint contains existing point";
+                creature->sendSystemMessage("@player_structure:no_room");
+                return 1;
+            }
+        }
+    }
 
-		debug() << "placing center x:" << x << " y:" << y << "placingFootprint x0:" << x0 << " y0:" << y0 << " x1:" << x1 << " y1:" << y1;
+    int rankRequired = serverTemplate->getCityRankRequired();
 
-		for (int i = 0; i < inRangeObjects.size(); ++i) {
-			SceneObject* scene = inRangeObjects.get(i).castTo<SceneObject*>();
+    if (city == nullptr && rankRequired > 0) {
+        creature->sendSystemMessage("@city/city:build_no_city");
+        return 1;
+    }
 
-			if (scene == nullptr)
-				continue;
+    if (city != nullptr) {
+        if (city->isZoningEnabled() && !city->hasZoningRights(creature->getObjectID())) {
+            creature->sendSystemMessage("@player_structure:no_rights");
+            return 1;
+        }
 
-			float l0 = -5; // Along the x axis.
-			float w0 = -5; // Along the y axis.
-			float l1 = 5;
-			float w1 = 5;
+        if (rankRequired != 0 && city->getCityRank() < rankRequired) {
+            StringIdChatParameter param("city/city", "rank_req");
+            param.setDI(rankRequired);
+            param.setTO("city/city", "rank" + String::valueOf(rankRequired));
+            creature->sendSystemMessage(param);
+            return 1;
+        }
 
-			if (getStructureFootprint(dynamic_cast<SharedStructureObjectTemplate*>(scene->getObjectTemplate()), scene->getDirectionAngle(), l0, w0, l1, w1))
-				continue;
+        if (serverTemplate->isCivicStructure() && !city->isMayor(creature->getObjectID())) {
+            creature->sendSystemMessage("@player_structure:cant_place_civic");
+            return 1;
+        }
 
-			float xx0 = scene->getPositionX() + (w0 + 0.1);
-			float yy0 = scene->getPositionY() + (l0 + 0.1);
-			float xx1 = scene->getPositionX() + (w1 - 0.1);
-			float yy1 = scene->getPositionY() + (l1 - 0.1);
+        if (serverTemplate->isUniqueStructure() && city->hasUniqueStructure(serverTemplate->getServerObjectCRC())) {
+            creature->sendSystemMessage("@player_structure:cant_place_unique");
+            return 1;
+        }
+    }
 
-			BoundaryRectangle rect(xx0, yy0, xx1, yy1);
+    Locker _lock(deed, creature);
 
-			debug() << "existing footprint xx0:" << xx0 << " yy0:" << yy0 << " xx1:" << xx1 << " yy1:" << yy1;
+    if (!deed->isASubChildOf(creature)) {
+        creature->sendSystemMessage("@player_structure:no_possession");
+        return 1;
+    }
 
-			// check 4 points of the current rect
-			if (rect.containsPoint(x0, y0) || rect.containsPoint(x0, y1) || rect.containsPoint(x1, y0) || rect.containsPoint(x1, y1)) {
-				debug() << "existing footprint contains placing point";
+    ManagedReference<PlayerObject*> ghost = creature->getPlayerObject();
+    if (ghost != nullptr) {
+        String abilityRequired = serverTemplate->getAbilityRequired();
+        if (!abilityRequired.isEmpty() && !ghost->hasAbility(abilityRequired)) {
+            creature->sendSystemMessage("@player_structure:" + abilityRequired);
+            return 1;
+        }
 
-				creature->sendSystemMessage("@player_structure:no_room"); // there is no room to place the structure here..
+        int lots = serverTemplate->getLotSize();
 
-				return 1;
-			}
+// Check if this deed is from a packed house
+bool isPackedDeed = HousePackupManager::instance()->hasSavedPayloadForDeed(deed->getObjectID());
 
-			if (placingFootprint.containsPoint(xx0, yy0) || placingFootprint.containsPoint(xx0, yy1) || placingFootprint.containsPoint(xx1, yy0) || placingFootprint.containsPoint(xx1, yy1) || (xx0 == x0 && yy0 == y0 && xx1 == x1 && yy1 == y1)) {
-				debug() << "placing footprint contains existing point";
+if (!isPackedDeed) {
+    // Normal deed - check and consume lots normally
+    if (!ghost->hasLotsRemaining(lots)) {
+        StringIdChatParameter param("@player_structure:not_enough_lots");
+        param.setDI(lots);
+        creature->sendSystemMessage(param);
+        return 1;
+    }
+} else {
+    // Packed deed - lots already consumed, no additional check needed
+    creature->sendSystemMessage("Placing packed house - lots already allocated to this deed.");
+}
+        
+        // If there IS a placeholder, we assume it has the right amount of lots
+        // and will be released before the new structure consumes lots
+    }
 
-				creature->sendSystemMessage("@player_structure:no_room"); // there is no room to place the structure here.
+    // Release lot placeholder BEFORE creating the new structure
+    // This frees up the lots that will be consumed by the new structure
+    HousePackupManager::instance()->releaseLotsPlaceholder(deed->getObjectID(), creature);
 
-				return 1;
-			}
-		}
-	}
+    ManagedReference<PlaceStructureSession*> session = new PlaceStructureSession(creature, deed);
+    creature->addActiveSession(SessionFacadeType::PLACESTRUCTURE, session);
 
-	int rankRequired = serverTemplate->getCityRankRequired();
+    session->constructStructure(x, y, angle);
 
-	if (city == nullptr && rankRequired > 0) {
-		creature->sendSystemMessage("@city/city:build_no_city"); // You must be in a city to place that structure.
-		return 1;
-	}
+    deed->destroyObjectFromWorld(true);
 
-	if (city != nullptr) {
-		if (city->isZoningEnabled() && !city->hasZoningRights(creature->getObjectID())) {
-			creature->sendSystemMessage("@player_structure:no_rights"); // You don't have the right to place that structure in this city. The mayor or one of the city milita must grant you zoning rights first.
-			return 1;
-		}
-
-		if (rankRequired != 0 && city->getCityRank() < rankRequired) {
-			StringIdChatParameter param("city/city", "rank_req"); // The city must be at least rank %DI (%TO) in order for you to place this structure.
-			param.setDI(rankRequired);
-			param.setTO("city/city", "rank" + String::valueOf(rankRequired));
-
-			creature->sendSystemMessage(param);
-			return 1;
-		}
-
-		if (serverTemplate->isCivicStructure() && !city->isMayor(creature->getObjectID())) {
-			creature->sendSystemMessage("@player_structure:cant_place_civic"); //"This structure must be placed within the borders of the city in which you are mayor."
-			return 1;
-		}
-
-		if (serverTemplate->isUniqueStructure() && city->hasUniqueStructure(serverTemplate->getServerObjectCRC())) {
-			creature->sendSystemMessage("@player_structure:cant_place_unique"); // This city can only support a single structure of this type.
-			return 1;
-		}
-	}
-
-	Locker _lock(deed, creature);
-
-	// Ensure that it is the correct deed, and that it is in a container in the creature's inventory.
-	if (!deed->isASubChildOf(creature)) {
-		creature->sendSystemMessage("@player_structure:no_possession"); // You no longer are in possession of the deed for this structure. Aborting construction.
-		return 1;
-	}
-
-	ManagedReference<PlayerObject*> ghost = creature->getPlayerObject();
-
-	if (ghost != nullptr) {
-		String abilityRequired = serverTemplate->getAbilityRequired();
-
-		if (!abilityRequired.isEmpty() && !ghost->hasAbility(abilityRequired)) {
-			creature->sendSystemMessage("@player_structure:" + abilityRequired);
-			return 1;
-		}
-
-		int lots = serverTemplate->getLotSize();
-
-		if (!ghost->hasLotsRemaining(lots)) {
-			StringIdChatParameter param("@player_structure:not_enough_lots");
-			param.setDI(lots);
-			creature->sendSystemMessage(param);
-			return 1;
-		}
-	}
-
-	// Validate that the structure can be placed at the given coordinates:
-	// Ensure that no other objects impede on this structures footprint, or overlap any city regions or no build areas.
-	// Make sure that the player has zoning rights in the area.
-
-	ManagedReference<PlaceStructureSession*> session = new PlaceStructureSession(creature, deed);
-	creature->addActiveSession(SessionFacadeType::PLACESTRUCTURE, session);
-
-	// Construct the structure.
-	session->constructStructure(x, y, angle);
-
-	// Remove the deed from it's container.
-	deed->destroyObjectFromWorld(true);
-
-	return 0;
+    return 0;
 }
 
 StructureObject* StructureManager::placeStructure(CreatureObject* creature, const String& structureTemplatePath, float x, float y, int angle, int persistenceLevel) {
@@ -645,11 +633,16 @@ StructureObject* StructureManager::placeCamp(CreatureObject* player, Customizati
 	return campObject;
 }
 
-int StructureManager::destroyStructure(StructureObject* structureObject, bool playEffect) {
-	Reference<DestroyStructureTask*> task = new DestroyStructureTask(structureObject, playEffect);
-	task->execute();
-
-	return 0;
+int StructureManager::destroyStructure(StructureObject* structureObject,
+                                       bool playEffect /*=false*/,
+                                       bool refundLots /*=true*/) {
+    Reference<DestroyStructureTask*> task =
+        new DestroyStructureTask(structureObject,
+                                 /*doEffect*/ playEffect,
+                                 /*killStuff*/ false,
+                                 /*refundLotsFlag*/ refundLots);
+    task->execute();
+    return 0;
 }
 
 String StructureManager::getTimeString(uint32 timestamp) {
@@ -793,103 +786,117 @@ Reference<SceneObject*> StructureManager::getInRangeParkingGarage(SceneObject* o
 }
 
 int StructureManager::redeedStructure(CreatureObject* creature) {
-	ManagedReference<DestroyStructureSession*> session = creature->getActiveSession(SessionFacadeType::DESTROYSTRUCTURE).castTo<DestroyStructureSession*>();
+    ManagedReference<DestroyStructureSession*> session =
+        creature->getActiveSession(SessionFacadeType::DESTROYSTRUCTURE)
+            .castTo<DestroyStructureSession*>();
+    if (session == nullptr)
+        return 0;
 
-	if (session == nullptr)
-		return 0;
+    ManagedReference<StructureObject*> structureObject = session->getStructureObject();
+    if (structureObject == nullptr)
+        return 0;
 
-	ManagedReference<StructureObject*> structureObject = session->getStructureObject();
+    Locker _locker(structureObject);
 
-	if (structureObject == nullptr)
-		return 0;
+    ManagedReference<StructureDeed*> deed =
+        server->getObject(structureObject->getDeedObjectID()).castTo<StructureDeed*>();
 
-	Locker _locker(structureObject);
+    int maint = structureObject->getSurplusMaintenance();
+    int redeedCost = structureObject->getRedeedCost();
 
-	ManagedReference<StructureDeed*> deed = server->getObject(structureObject->getDeedObjectID()).castTo<StructureDeed*>();
+    TransactionLog trx(creature, TrxCode::STRUCTUREDEED, structureObject);
+    trx.addState("subjectIsRedeedable", structureObject->isRedeedable());
+    trx.addState("subjectDeedObjectID", deed != nullptr ? deed->getObjectID() : 0);
 
-	int maint = structureObject->getSurplusMaintenance();
-	int redeedCost = structureObject->getRedeedCost();
+    if (deed != nullptr && structureObject->isRedeedable()) {
+        Locker _lock(deed, structureObject);
 
-	TransactionLog trx(creature, TrxCode::STRUCTUREDEED, structureObject);
+        ManagedReference<SceneObject*> inventory = creature->getSlottedObject("inventory");
 
-	trx.addState("subjectIsRedeedable", structureObject->isRedeedable());
-	trx.addState("subjectDeedObjectID", deed != nullptr ? deed->getObjectID() : 0);
+        bool isSelfPoweredHarvester = false;
+        HarvesterObject* harvester = structureObject.castTo<HarvesterObject*>();
+        if (harvester != nullptr)
+            isSelfPoweredHarvester = harvester->isSelfPowered();
 
-	if (deed != nullptr && structureObject->isRedeedable()) {
-		Locker _lock(deed, structureObject);
+        // capacity check
+        if (inventory == nullptr ||
+            inventory->getCountableObjectsRecursive() >
+                (inventory->getContainerVolumeLimit() - (isSelfPoweredHarvester ? 2 : 1))) {
 
-		ManagedReference<SceneObject*> inventory = creature->getSlottedObject("inventory");
+            if (isSelfPoweredHarvester) {
+                creature->sendSystemMessage("@player_structure:inventory_full_selfpowered");
+                trx.abort() << "@player_structure:inventory_full_selfpowered";
+            } else {
+                creature->sendSystemMessage("@player_structure:inventory_full");
+                trx.abort() << "@player_structure:inventory_full";
+            }
 
-		bool isSelfPoweredHarvester = false;
-		HarvesterObject* harvester = structureObject.castTo<HarvesterObject*>();
+            creature->sendSystemMessage("@player_structure:deed_reclaimed_failed");
+            return session->cancelSession();
+        } else {
+            // self-powered harvester reward
+            if (isSelfPoweredHarvester) {
+                Reference<SceneObject*> rewardSceno =
+                    server->createObject(STRING_HASHCODE("object/tangible/veteran_reward/harvester.iff"), 1);
 
-		if (harvester != nullptr)
-			isSelfPoweredHarvester = harvester->isSelfPowered();
+                if (rewardSceno == nullptr) {
+                    creature->sendSystemMessage("@player_structure:deed_reclaimed_failed");
+                    trx.abort() << "failed to createObject veteran_reward/harvester";
+                    return session->cancelSession();
+                }
 
-		if (inventory == nullptr || inventory->getCountableObjectsRecursive() > (inventory->getContainerVolumeLimit() - (isSelfPoweredHarvester ? 2 : 1))) {
-			if (isSelfPoweredHarvester) {
-				// This installation can not be destroyed because there is no room for the Self Powered Harvester Kit in your inventory.
-				creature->sendSystemMessage("@player_structure:inventory_full_selfpowered");
-				trx.abort() << "@player_structure:inventory_full_selfpowered";
-			} else {
-				// This installation can not be redeeded because your inventory does not have room to put the deed.
-				creature->sendSystemMessage("@player_structure:inventory_full");
-				trx.abort() << "@player_structure:inventory_full";
-			}
+                TransactionLog trxReward(structureObject, creature, rewardSceno, TrxCode::STRUCTUREDEED, false);
+                trxReward.addState("srcIsSelfPoweredHarvester", isSelfPoweredHarvester);
+                trxReward.groupWith(trx);
 
-			creature->sendSystemMessage("@player_structure:deed_reclaimed_failed"); // Structure destroy and deed reclaimed FAILED!
-			return session->cancelSession();
-		} else {
-			if (isSelfPoweredHarvester) {
-				Reference<SceneObject*> rewardSceno = server->createObject(STRING_HASHCODE("object/tangible/veteran_reward/harvester.iff"), 1);
-				if (rewardSceno == nullptr) {
-					creature->sendSystemMessage("@player_structure:deed_reclaimed_failed"); // Structure destroy and deed reclaimed FAILED!
-					trx.abort() << "failed to createObject veteran_reward/harvester";
-					return session->cancelSession();
-				}
+                if (!inventory->transferObject(rewardSceno, -1, false, true)) { // allow overflow
+                    trxReward.abort() << "Failed to reclaim deed";
+                    creature->sendSystemMessage("@player_structure:deed_reclaimed_failed");
+                    rewardSceno->destroyObjectFromDatabase(true);
+                    return session->cancelSession();
+                }
 
-				TransactionLog trxReward(structureObject, creature, rewardSceno, TrxCode::STRUCTUREDEED, false);
-				trxReward.addState("srcIsSelfPoweredHarvester", isSelfPoweredHarvester);
-				trxReward.groupWith(trx);
+                harvester->setSelfPowered(false);
+                inventory->broadcastObject(rewardSceno, true);
+                creature->sendSystemMessage("@player_structure:selfpowered");
+            }
 
-				// Transfer to player
-				if (!inventory->transferObject(rewardSceno, -1, false, true)) { // Allow overflow
-					trxReward.abort() << "Failed to reclaim deed";
-					creature->sendSystemMessage("@player_structure:deed_reclaimed_failed"); // Structure destroy and deed reclaimed FAILED!
-					rewardSceno->destroyObjectFromDatabase(true);
-					return session->cancelSession();
-				}
+            // deed bookkeeping
+            TransactionLog trxDeed(structureObject, creature, deed, TrxCode::STRUCTUREDEED);
+            trxDeed.addState("structureOriginalObjectID", structureObject->getObjectID());
+            trxDeed.groupWith(trx);
 
-				harvester->setSelfPowered(false);
+            deed->setSurplusMaintenance(maint - redeedCost);
+            deed->setSurplusPower(structureObject->getSurplusPower());
 
-				inventory->broadcastObject(rewardSceno, true);
-				creature->sendSystemMessage("@player_structure:selfpowered");
-			}
+            // move packed payload from building -> deed BEFORE destroying the structure
+            HousePackupManager::instance()->attachPayloadToDeedFromBuilding(
+                structureObject->getObjectID(), deed->getObjectID());
 
-			TransactionLog trxDeed(structureObject, creature, deed, TrxCode::STRUCTUREDEED);
-			trxDeed.addState("structureOriginalObjectID", structureObject->getObjectID());
-			trxDeed.groupWith(trx);
+            // make sure the deed itself won't be deleted with the structure
+            structureObject->setDeedObjectID(0);
 
-			deed->setSurplusMaintenance(maint - redeedCost);
-			deed->setSurplusPower(structureObject->getSurplusPower());
+            // Destroy structure — let normal Core3 behavior refund lots here.
+            // If your destroyStructure signature is (StructureObject*, bool),
+            // call: destroyStructure(structureObject, /*playEffect*/false);
+            // If it's (StructureObject*, bool, bool refundLots), pass true:
+            destroyStructure(structureObject, /*playEffect*/false, /*refundLots*/false);
 
-			structureObject->setDeedObjectID(0); // Set this to 0 so the deed doesn't get destroyed with the structure.
+            // hand deed back to player
+            if (!inventory->transferObject(deed, -1, true)) {
+                trx.abort() << "failed to transfer deed to player inventory";
+            }
 
-			destroyStructure(structureObject);
+            inventory->broadcastObject(deed, true);
+            creature->sendSystemMessage("@player_structure:deed_reclaimed");
+        }
+    } else {
+        // not redeedable: normal destroy (refund lots)
+        destroyStructure(structureObject, /*playEffect*/false, /*refundLots*/true);
+        creature->sendSystemMessage("@player_structure:structure_destroyed");
+    }
 
-			if (!inventory->transferObject(deed, -1, true)) {
-				trx.abort() << "failed to transfer deed to player inventory";
-			}
-
-			inventory->broadcastObject(deed, true);
-			creature->sendSystemMessage("@player_structure:deed_reclaimed"); // Structure destroyed and deed reclaimed.
-		}
-	} else {
-		destroyStructure(structureObject);
-		creature->sendSystemMessage("@player_structure:structure_destroyed"); // Structured destroyed.
-	}
-
-	return session->cancelSession();
+    return session->cancelSession();
 }
 
 void StructureManager::promptDeleteAllItems(CreatureObject* creature, StructureObject* structure) {

--- a/MMOCoreORB/src/server/zone/managers/structure/StructureManager.h
+++ b/MMOCoreORB/src/server/zone/managers/structure/StructureManager.h
@@ -72,7 +72,7 @@ public:
 	 * post: structure deleted*
 	 * @param structure The structure that is being destroyed.
 	 */
-	int destroyStructure(StructureObject* structureObject, bool playEffect = false);
+	int destroyStructure(StructureObject* structureObject, bool playEffect = false, bool refundLots = true);
 
 	/**
 	 * Redeeds the structure, returning it to the player in deed form with any surplus maintenance and power attached.

--- a/MMOCoreORB/src/server/zone/managers/structure/tasks/DestroyStructureTask.h
+++ b/MMOCoreORB/src/server/zone/managers/structure/tasks/DestroyStructureTask.h
@@ -21,13 +21,19 @@ protected:
 	ManagedReference<StructureObject*> structureObject;
 	bool playEffect;
 	bool killOccupants;
+	// NEW: whether the caller wants lots to be refunded.
+	bool refundLots;
 
 public:
-	DestroyStructureTask(StructureObject* structure, bool doEffect = false, bool killStuff = false) {
-		structureObject = structure;
-		playEffect = doEffect;
-		killOccupants = killStuff;
-
+	// UPDATED CTOR: added refundLotsFlag (default = true) to preserve old call sites.
+	DestroyStructureTask(StructureObject* structure,
+	                     bool doEffect = false,
+	                     bool killStuff = false,
+	                     bool refundLotsFlag = true)
+		: structureObject(structure),
+		  playEffect(doEffect),
+		  killOccupants(killStuff),
+		  refundLots(refundLotsFlag) {
 		setCustomTaskQueue("slowQueue");
 	}
 
@@ -35,15 +41,12 @@ public:
 		Locker locker(structureObject);
 
 		ManagedReference<Zone*> zone = structureObject->getZone();
-
 		if (zone == nullptr)
 			return;
 
 		ZoneServer* zoneServer = structureObject->getZoneServer();
-
 		if (zoneServer != nullptr && zoneServer->isServerLoading()) {
 			schedule(1000);
-
 			return;
 		}
 
@@ -51,38 +54,37 @@ public:
 		float y = structureObject->getPositionY();
 		float z = zone->getHeight(x, y);
 
-		if (playEffect)
-		{
-			PlayClientEffectLoc* explodeLoc = new PlayClientEffectLoc("clienteffect/combat_explosion_lair_large.cef", structureObject->getZone()->getZoneName(), structureObject->getPositionX(), structureObject->getPositionZ(), structureObject->getPositionY());
+		if (playEffect) {
+			PlayClientEffectLoc* explodeLoc = new PlayClientEffectLoc(
+				"clienteffect/combat_explosion_lair_large.cef",
+				structureObject->getZone()->getZoneName(),
+				structureObject->getPositionX(),
+				structureObject->getPositionZ(),
+				structureObject->getPositionY());
 			structureObject->broadcastMessage(explodeLoc, false);
 		}
 
 		if (structureObject->isBuildingObject()) {
 			ManagedReference<BuildingObject*> buildingObject =
-					cast<BuildingObject*>(structureObject.get());
+			    cast<BuildingObject*>(structureObject.get());
 
 			for (uint32 i = 1; i <= buildingObject->getTotalCellNumber(); ++i) {
 				ManagedReference<CellObject*> cellObject = buildingObject->getCell(i);
-
 				if (cellObject == nullptr)
 					continue;
 
 				int childObjects = cellObject->getContainerObjectsSize();
-
 				if (childObjects <= 0)
 					continue;
 
-				//Traverse the vector backwards since the size will change as objects are removed.
+				// Traverse backwards since the size will change as objects are removed.
 				for (int j = childObjects - 1; j >= 0; --j) {
-					ManagedReference<SceneObject*> obj =
-							cellObject->getContainerObject(j);
+					ManagedReference<SceneObject*> obj = cellObject->getContainerObject(j);
 
 					if (obj->isPlayerCreature() || obj->isPet()) {
-						CreatureObject* playerCreature =
-								cast<CreatureObject*>(obj.get());
+						CreatureObject* playerCreature = cast<CreatureObject*>(obj.get());
 
 						structureObject->unlock();
-
 						try {
 							Locker plocker(playerCreature);
 
@@ -96,17 +98,15 @@ public:
 						} catch (...) {
 							playerCreature->error("unreported exception caught while teleporting");
 						}
-
 						structureObject->wlock();
 					}
 				}
 			}
-
 		}
 
-		//Get the owner of the structure, and remove the structure from their possession.
+		// Get the owner and remove structure ownership (and optionally refund lots)
 		ManagedReference<SceneObject*> owner = zone->getZoneServer()->getObject(
-				structureObject->getOwnerObjectID());
+			structureObject->getOwnerObjectID());
 
 		if (owner != nullptr) {
 			ManagedReference<SceneObject*> ghost = owner->getSlottedObject("ghost");
@@ -115,8 +115,15 @@ public:
 				PlayerObject* playerObject = cast<PlayerObject*>(ghost.get());
 				playerObject->removeOwnedStructure(structureObject);
 
-				uint64 waypointID = structureObject->getWaypointID();
+				// REFUND LOTS HERE IF YOUR FORK EXPECTS IT IN THIS TASK:
+				if (refundLots) {
+					int lots = structureObject->getLotSize();
+					// TODO: call your fork’s specific API to add lots back.
+					// Example (if available in your fork):
+					// playerObject->addLots(lots);
+				}
 
+				uint64 waypointID = structureObject->getWaypointID();
 				if (waypointID != 0)
 					playerObject->removeWaypoint(waypointID, true, true);
 			}
@@ -129,4 +136,3 @@ public:
 };
 
 #endif /* DESTROYSTRUCTURETASK_H_ */
-

--- a/MMOCoreORB/src/server/zone/objects/creature/commands/PlaceStructureModeCommand.h
+++ b/MMOCoreORB/src/server/zone/objects/creature/commands/PlaceStructureModeCommand.h
@@ -9,6 +9,9 @@
 #include "server/zone/packets/player/EnterStructurePlacementModeMessage.h"
 #include "templates/manager/TemplateManager.h"
 #include "templates/faction/Factions.h"
+// add with other includes
+#include "server/zone/managers/housepackup/HousePackupManager.h"
+
 
 class PlaceStructureModeCommand : public QueueCommand {
 public:
@@ -95,9 +98,14 @@ public:
 
 		int lots = serverTemplate->getLotSize();
 
+// If this deed was from a packed house, free the temporary lot-hold now
+		HousePackupManager::instance()->releaseLotsPlaceholder(deed->getObjectID());
+
+// Now perform the normal lots check
 		if (!ghost->hasLotsRemaining(lots)) {
-			StringIdChatParameter param("@player_structure:not_enough_lots");
-			param.setDI(lots);
+    		StringIdChatParameter param("@player_structure:not_enough_lots");
+    		param.setDI(lots);
+
 			creature->sendSystemMessage(param);
 			return GENERALERROR;
 		}

--- a/MMOCoreORB/src/server/zone/objects/player/PlayerObjectImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/player/PlayerObjectImplementation.cpp
@@ -11,6 +11,10 @@
 #include "server/zone/managers/mission/MissionManager.h"
 #include "server/zone/managers/combat/CombatManager.h"
 #include "server/zone/managers/structure/StructureManager.h"
+#include "server/zone/managers/housepackup/HousePackupManager.h"
+#include "server/zone/objects/tangible/deed/structure/StructureDeed.h"
+#include "templates/manager/TemplateManager.h"
+#include "templates/tangible/SharedStructureObjectTemplate.h"
 #include "server/zone/managers/vendor/VendorManager.h"
 #include "server/zone/managers/frs/FrsManager.h"
 #include "server/chat/ChatManager.h"
@@ -3062,21 +3066,48 @@ void PlayerObjectImplementation::deleteAllWaypoints() {
 }
 
 int PlayerObjectImplementation::getLotsRemaining() {
-	Locker locker(asPlayerObject());
+    Locker locker(asPlayerObject());
 
-	int lotsRemaining = maximumLots;
+    int lotsRemaining = maximumLots;
 
-	for (int i = 0; i < ownedStructures.size(); ++i) {
-		auto oid = ownedStructures.get(i);
+    // Subtract lots consumed by placed structures
+    for (int i = 0; i < ownedStructures.size(); ++i) {
+        auto oid = ownedStructures.get(i);
 
-		Reference<StructureObject*> structure = getZoneServer()->getObject(oid).castTo<StructureObject*>();
+        Reference<StructureObject*> structure = getZoneServer()->getObject(oid).castTo<StructureObject*>();
 
-		if (structure != nullptr) {
-			lotsRemaining = lotsRemaining - structure->getLotSize();
-		}
-	}
+        if (structure != nullptr) {
+            lotsRemaining = lotsRemaining - structure->getLotSize();
+        }
+    }
 
-	return lotsRemaining;
+    // Subtract lots consumed by packed deeds in inventory
+    CreatureObject* creature = dynamic_cast<CreatureObject*>(parent.get().get());
+    if (creature != nullptr) {
+        SceneObject* inventory = creature->getSlottedObject("inventory");
+        if (inventory != nullptr) {
+            for (int i = 0; i < inventory->getContainerObjectsSize(); ++i) {
+                SceneObject* item = inventory->getContainerObject(i);
+                if (item != nullptr && item->isDeedObject()) {
+                    // Check if this deed has packed contents
+                    if (HousePackupManager::instance()->hasSavedPayloadForDeed(item->getObjectID())) {
+                        StructureDeed* deed = cast<StructureDeed*>(item);
+                        if (deed != nullptr) {
+                            // Get lot size from deed template
+                            String templatePath = deed->getGeneratedObjectTemplate();
+                            Reference<SharedStructureObjectTemplate*> tmpl = dynamic_cast<SharedStructureObjectTemplate*>(
+                                TemplateManager::instance()->getTemplate(templatePath.hashCode()));
+                            if (tmpl != nullptr) {
+                                lotsRemaining -= tmpl->getLotSize();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return lotsRemaining;
 }
 
 int PlayerObjectImplementation::getOwnedChatRoomCount() {

--- a/MMOCoreORB/src/server/zone/objects/tangible/deed/components/PlaceStructureComponent.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/deed/components/PlaceStructureComponent.cpp
@@ -4,7 +4,6 @@
  *  Created on: Feb 5, 2012
  *      Author: xyborn
  */
-
 #include "PlaceStructureComponent.h"
 #include "server/zone/objects/creature/CreatureObject.h"
 #include "server/zone/managers/structure/StructureManager.h"
@@ -12,25 +11,44 @@
 #include "server/zone/objects/installation/InstallationObject.h"
 #include "server/zone/objects/tangible/deed/structure/StructureDeed.h"
 #include "server/zone/Zone.h"
+// Added for restore hook
+#include "server/zone/managers/housepackup/HousePackupManager.h"
+#include "server/zone/objects/building/BuildingObject.h"
 
 int PlaceStructureComponent::placeStructure(StructureDeed* deed, CreatureObject* creature, float x, float y, int angle) const {
-	Zone* zone = creature->getZone();
-
-	if (zone != nullptr)
-		StructureManager::instance()->placeStructureFromDeed(creature, deed, x, y, angle);
-
-	return 0;
+    Zone* zone = creature != nullptr ? creature->getZone() : nullptr;
+    if (zone != nullptr) {
+        // Delegates to StructureManager which actually creates & places the structure,
+        // and will invoke notifyStructurePlaced(...) on success.
+        StructureManager::instance()->placeStructureFromDeed(creature, deed, x, y, angle);
+    }
+    return 0;
 }
 
 int PlaceStructureComponent::notifyStructurePlaced(StructureDeed* deed, CreatureObject* creature, StructureObject* structureObject) const {
-	structureObject->setSurplusMaintenance(deed->getSurplusMaintenance());
-	structureObject->setSurplusPower(deed->getSurplusPower());
-
-	if (structureObject->isInstallationObject()) {
-		InstallationObject* installationObject = cast<InstallationObject*>(structureObject);
-		installationObject->setExtractionRate(deed->getExtractionRate());
-		installationObject->setHopperSizeMax(deed->getHopperSize());
-	}
-
-	return 0;
+    if (structureObject == nullptr || deed == nullptr)
+        return 0;
+    
+    // Preserve deed-carried resources/settings
+    structureObject->setSurplusMaintenance(deed->getSurplusMaintenance());
+    structureObject->setSurplusPower(deed->getSurplusPower());
+    
+    if (structureObject->isInstallationObject()) {
+        InstallationObject* installationObject = cast<InstallationObject*>(structureObject);
+        if (installationObject != nullptr) {
+            installationObject->setExtractionRate(deed->getExtractionRate());
+            installationObject->setHopperSizeMax(deed->getHopperSize());
+        }
+    }
+    
+    // Restore packed house contents if this is a building (house)
+    if (structureObject->isBuildingObject()) {
+        BuildingObject* building = cast<BuildingObject*>(structureObject);
+        if (building != nullptr) {
+            // This will restore any items previously packed into this deed
+            HousePackupManager::instance()->restoreFromDeed(building, deed, creature);
+        }
+    }
+    
+    return 0;
 }

--- a/MMOCoreORB/src/server/zone/objects/tangible/terminal/components/StructureTerminalMenuComponent.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/terminal/components/StructureTerminalMenuComponent.cpp
@@ -19,72 +19,81 @@
 #include "server/zone/objects/intangible/PetControlDevice.h"
 #include "server/zone/managers/creature/PetManager.h"
 
-void StructureTerminalMenuComponent::fillObjectMenuResponse(SceneObject* sceneObject, ObjectMenuResponse* menuResponse, CreatureObject* creature) const {
+// NEW: House pack-up manager
+#include "server/zone/managers/housepackup/HousePackupManager.h"
 
-	if(!sceneObject->isTerminal())
+static const int RADIAL_ROOT_MANAGEMENT = 118;
+static const int RADIAL_ROOT_PERMISSIONS = 117;
+
+// New action ID for Pack Up House
+static const int RADIAL_PACK_UP_HOUSE = 240;
+
+void StructureTerminalMenuComponent::fillObjectMenuResponse(SceneObject* sceneObject, ObjectMenuResponse* menuResponse, CreatureObject* creature) const {
+	if (sceneObject == nullptr || menuResponse == nullptr || creature == nullptr)
 		return;
 
-	if(!creature->isPlayerCreature())
+	if (!sceneObject->isTerminal())
+		return;
+
+	if (!creature->isPlayerCreature())
 		return;
 
 	ManagedReference<PlayerObject*> ghost = creature->getPlayerObject();
-	if( ghost == nullptr )
+	if (ghost == nullptr)
 		return;
 
 	ManagedReference<Terminal*> terminal = cast<Terminal*>(sceneObject);
-	if(terminal == nullptr)
+	if (terminal == nullptr)
 		return;
 
 	ManagedReference<StructureObject*> structureObject = cast<StructureObject*>(terminal->getControlledObject());
-
 	if (structureObject == nullptr)
 		return;
 
+	// Civic structures
 	if (structureObject->isCivicStructure()) {
 		if (structureObject->isOnAdminList(creature)) {
-			menuResponse->addRadialMenuItem(118, 3, "@player_structure:management"); //Structure Management
-			menuResponse->addRadialMenuItemToRadialID(118, 128, 3, "@player_structure:permission_destroy"); //Destroy Structure
-			menuResponse->addRadialMenuItemToRadialID(118, 124, 3, "@player_structure:management_status"); //Status
+			menuResponse->addRadialMenuItem(RADIAL_ROOT_MANAGEMENT, 3, "@player_structure:management"); // Structure Management
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 128, 3, "@player_structure:permission_destroy"); // Destroy Structure
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 124, 3, "@player_structure:management_status");  // Status
 
 			if (structureObject->isBuildingObject()) {
-				menuResponse->addRadialMenuItemToRadialID(118, 50, 3, "@player_structure:management_name_structure"); //Name Structure
-				menuResponse->addRadialMenuItemToRadialID(118, 201, 3, "@player_structure:delete_all_items"); //Delete all items
-				menuResponse->addRadialMenuItemToRadialID(118, 202, 3, "@player_structure:move_first_item"); //Find Lost Items
+				menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 50, 3, "@player_structure:management_name_structure"); // Name Structure
+				menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 201, 3, "@player_structure:delete_all_items");         // Delete all items
+				menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 202, 3, "@player_structure:move_first_item");          // Find Lost Items
 
-				// Not all civic buildings have signs.  Check to see if build already has one before allowing a change
+				// Only some civic buildings have signs
 				BuildingObject* building = cast<BuildingObject*>(structureObject.get());
-				if( building != nullptr && building->getSignObject() != nullptr )
-					menuResponse->addRadialMenuItemToRadialID(118, 69, 3, "@player_structure:management_change_sign"); //Change Sign
+				if (building != nullptr && building->getSignObject() != nullptr)
+					menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 69, 3, "@player_structure:management_change_sign"); // Change Sign
 			}
 		}
-
 		return;
 	}
 
+	// Player / non-civic structures
 	if (structureObject->isOnAdminList(creature)) {
-		menuResponse->addRadialMenuItem(118, 3, "@player_structure:management"); //Structure Management
-		menuResponse->addRadialMenuItemToRadialID(118, 128, 3, "@player_structure:permission_destroy"); //Destroy Structure
-		menuResponse->addRadialMenuItemToRadialID(118, 124, 3, "@player_structure:management_status"); //Status
-		menuResponse->addRadialMenuItemToRadialID(118, 129, 3, "@player_structure:management_pay"); //Pay Maintenance
+		menuResponse->addRadialMenuItem(RADIAL_ROOT_MANAGEMENT, 3, "@player_structure:management"); // Structure Management
+		menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 128, 3, "@player_structure:permission_destroy"); // Destroy Structure
+		menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 124, 3, "@player_structure:management_status");  // Status
+		menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 129, 3, "@player_structure:management_pay");     // Pay Maintenance
 
 		// Allow withdraw for houses (non-civic buildings) and guild halls
-		if (structureObject->isGuildHall()
-    		|| (structureObject->isBuildingObject() && !structureObject->isCivicStructure())) {
-    		menuResponse->addRadialMenuItemToRadialID(118, 70, 3, "@player_structure:take_maintenance"); // Withdraw Maintenance
+		if (structureObject->isGuildHall() || (structureObject->isBuildingObject() && !structureObject->isCivicStructure())) {
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 70, 3, "@player_structure:take_maintenance"); // Withdraw Maintenance
 		}
 
-		menuResponse->addRadialMenuItemToRadialID(118, 50, 3, "@player_structure:management_name_structure"); //Name Structure
+		menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 50, 3, "@player_structure:management_name_structure"); // Name Structure
 
+		// Droid assignment option if user has a droid control device
 		ManagedReference<SceneObject*> datapad = creature->getSlottedObject("datapad");
-		if(datapad != nullptr) {
+		if (datapad != nullptr) {
 			for (int i = 0; i < datapad->getContainerObjectsSize(); ++i) {
 				ManagedReference<SceneObject*> object = datapad->getContainerObject(i);
-
 				if (object != nullptr && object->isPetControlDevice()) {
-					PetControlDevice* device = cast<PetControlDevice*>( object.get());
-
-					if (device->getPetType() == PetManager::DROIDPET) {
-						menuResponse->addRadialMenuItemToRadialID(118, 131, 3, "@player_structure:assign_droid"); //Assign Droid
+					PetControlDevice* device = cast<PetControlDevice*>(object.get());
+					if (device != nullptr && device->getPetType() == PetManager::DROIDPET) {
+						menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 131, 3, "@player_structure:assign_droid"); // Assign Droid
 						break;
 					}
 				}
@@ -92,182 +101,203 @@ void StructureTerminalMenuComponent::fillObjectMenuResponse(SceneObject* sceneOb
 		}
 
 		if (structureObject->isBuildingObject()) {
-			menuResponse->addRadialMenuItemToRadialID(118, 127, 3, "@player_structure:management_residence"); //Declare Residence
-			menuResponse->addRadialMenuItemToRadialID(118, 125, 3, "@player_structure:management_privacy"); //Privacy
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 127, 3, "@player_structure:management_residence"); // Declare Residence
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 125, 3, "@player_structure:management_privacy");   // Privacy
 
-			if (creature->hasSkill("crafting_artisan_business_01") && structureObject->isOnAdminList(creature)) {
+			if (creature->hasSkill("crafting_artisan_business_01")) {
 				BuildingObject* building = cast<BuildingObject*>(structureObject.get());
-				if(!building->hasAccessFee())
-					menuResponse->addRadialMenuItemToRadialID(118, 68, 3, "@player_structure:management_add_turnstile"); //Set Access Fee
-				else
-					menuResponse->addRadialMenuItemToRadialID(118, 68, 3, "@player_structure:management_remove_turnstile"); //Remove Access Fee
-
+				if (building != nullptr) {
+					if (!building->hasAccessFee())
+						menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 68, 3, "@player_structure:management_add_turnstile"); // Set Access Fee
+					else
+						menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 68, 3, "@player_structure:management_remove_turnstile"); // Remove Access Fee
+				}
 			}
 
 			if (creature->hasSkill("crafting_artisan_business_03"))
-				menuResponse->addRadialMenuItemToRadialID(118, 130, 3, "@player_structure:create_vendor"); //Create Vendor
+				menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 130, 3, "@player_structure:create_vendor"); // Create Vendor
 
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 69, 3, "@player_structure:management_change_sign"); // Change Sign
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 201, 3, "@player_structure:delete_all_items");       // Delete all items
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 202, 3, "@player_structure:move_first_item");        // Find Lost Items
 
-			menuResponse->addRadialMenuItemToRadialID(118, 69, 3, "@player_structure:management_change_sign"); //Change Sign
-			menuResponse->addRadialMenuItemToRadialID(118, 201, 3, "@player_structure:delete_all_items"); //Delete all items
-			menuResponse->addRadialMenuItemToRadialID(118, 202, 3, "@player_structure:move_first_item"); //Find Lost Items
+			// NEW: Pack Up House (non-civic only)
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, RADIAL_PACK_UP_HOUSE, 3, "Pack Up House");
+			// If you localize, replace with: @player_structure:pack_up_house
 		}
 
-		menuResponse->addRadialMenuItem(117, 3, "@player_structure:permissions"); //Structure Permissions
-		menuResponse->addRadialMenuItemToRadialID(117, 121, 3, "@player_structure:permission_admin"); //Administrator List
+		// Permissions submenu
+		menuResponse->addRadialMenuItem(RADIAL_ROOT_PERMISSIONS, 3, "@player_structure:permissions"); // Structure Permissions
+		menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_PERMISSIONS, 121, 3, "@player_structure:permission_admin");  // Administrator List
 
 		if (structureObject->isBuildingObject()) {
-			menuResponse->addRadialMenuItemToRadialID(117, 119, 3, "@player_structure:permission_enter"); //Entry List
-			menuResponse->addRadialMenuItemToRadialID(117, 120, 3, "@player_structure:permission_banned"); //Ban List
-			menuResponse->addRadialMenuItemToRadialID(117, 122, 3, "@player_structure:permission_vendor"); //Vendor List
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_PERMISSIONS, 119, 3, "@player_structure:permission_enter");  // Entry List
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_PERMISSIONS, 120, 3, "@player_structure:permission_banned"); // Ban List
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_PERMISSIONS, 122, 3, "@player_structure:permission_vendor"); // Vendor List
 		}
-	} else if(structureObject->isOnPermissionList("VENDOR", creature)) {
+	} else if (structureObject->isOnPermissionList("VENDOR", creature)) {
 		if (creature->hasSkill("crafting_artisan_business_03")) {
-			menuResponse->addRadialMenuItem(118, 3, "@player_structure:management"); //Structure Management
-			menuResponse->addRadialMenuItemToRadialID(118, 130, 3, "@player_structure:create_vendor"); //Create Vendor
+			menuResponse->addRadialMenuItem(RADIAL_ROOT_MANAGEMENT, 3, "@player_structure:management"); // Structure Management
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 130, 3, "@player_structure:create_vendor");      // Create Vendor
 		}
 	}
 }
 
 int StructureTerminalMenuComponent::handleObjectMenuSelect(SceneObject* sceneObject, CreatureObject* creature, byte selectedID) const {
-	ManagedReference<Terminal*> terminal = cast<Terminal*>(sceneObject);
-	if(terminal == nullptr)
+	if (sceneObject == nullptr || creature == nullptr)
 		return 1;
 
-	if(!creature->isPlayerCreature())
+	ManagedReference<Terminal*> terminal = cast<Terminal*>(sceneObject);
+	if (terminal == nullptr)
+		return 1;
+
+	if (!creature->isPlayerCreature())
 		return 1;
 
 	ManagedReference<PlayerObject*> ghost = creature->getPlayerObject();
-	if( ghost == nullptr )
+	if (ghost == nullptr)
 		return 1;
 
 	ManagedReference<StructureObject*> structureObject = cast<StructureObject*>(terminal->getControlledObject());
-
 	if (structureObject == nullptr)
 		return 1;
 
 	ManagedReference<Zone*> zone = structureObject->getZone();
-
 	if (zone == nullptr)
 		return 1;
 
+	// Civic structures
 	if (structureObject->isCivicStructure()) {
 		if (structureObject->isOnAdminList(creature)) {
 			StructureManager* structureManager = StructureManager::instance();
-
 			Locker structureLocker(structureObject, creature);
 
 			switch (selectedID) {
+				case 201:
+					structureManager->promptDeleteAllItems(creature, structureObject);
+					break;
+				case 202:
+					structureManager->promptFindLostItems(creature, structureObject);
+					break;
+				case 128:
+					creature->executeObjectControllerAction(0x18FC1726, structureObject->getObjectID(), ""); // destroyStructure
+					break;
+				case 50:
+					structureManager->promptNameStructure(creature, structureObject, nullptr);
+					break;
+				case 124:
+					creature->executeObjectControllerAction(0x13F7E585, structureObject->getObjectID(), ""); // structureStatus
+					break;
+				case 69:
+					structureManager->promptSelectSign(structureObject, creature);
+					break;
+				default:
+					break;
+			}
+		}
+		return 0;
+	}
+
+	// Player / non-civic structures
+	if (structureObject->isOnAdminList(creature)) {
+		StructureManager* structureManager = StructureManager::instance();
+		Locker structureLocker(structureObject, creature);
+
+		switch (selectedID) {
 			case 201:
 				structureManager->promptDeleteAllItems(creature, structureObject);
 				break;
 			case 202:
 				structureManager->promptFindLostItems(creature, structureObject);
 				break;
+			case 121:
+				structureObject->sendPermissionListTo(creature, "ADMIN");
+				break;
+			case 119:
+				structureObject->sendPermissionListTo(creature, "ENTRY");
+				break;
+			case 120:
+				structureObject->sendPermissionListTo(creature, "BAN");
+				break;
+			case 122:
+				structureObject->sendPermissionListTo(creature, "VENDOR");
+				break;
 			case 128:
-				creature->executeObjectControllerAction(0x18FC1726, structureObject->getObjectID(), ""); //destroyStructure
+				creature->executeObjectControllerAction(0x18FC1726, structureObject->getObjectID(), ""); // destroyStructure
+				break;
+			case 129:
+				creature->executeObjectControllerAction(0xE7E35B30, structureObject->getObjectID(), ""); // payMaintenance
+				break;
+			case 70:
+				structureManager->promptWithdrawMaintenance(structureObject, creature);
+				break;
+			case 124:
+				creature->executeObjectControllerAction(0x13F7E585, structureObject->getObjectID(), ""); // structureStatus
+				break;
+			case 127:
+				creature->executeObjectControllerAction(0xF59E3CE1, structureObject->getObjectID(), ""); // declareResidence
+				break;
+			case 125:
+				creature->executeObjectControllerAction(0x786CC38E, structureObject->getObjectID(), ""); // setPrivacy
+				break;
+			case 68:
+				if (structureObject->isBuildingObject()) {
+					BuildingObject* building = cast<BuildingObject*>(structureObject.get());
+					if (building != nullptr) {
+						if (!building->hasAccessFee()) {
+							if (!building->canChangeAccessFee()) {
+								StringIdChatParameter param("@player_structure:turnstile_wait");
+								param.setDI(building->getAccessFeeDelay());
+								creature->sendSystemMessage(param);
+								return 0;
+							}
+							ManagedReference<StructureSetAccessFeeSession*> session = new StructureSetAccessFeeSession(creature, building);
+							if (session->initializeSession() == 1) {
+								creature->addActiveSession(SessionFacadeType::SETSTRUCTUREACCESSFEE, session);
+								session->promptSetAccessFee();
+							}
+						} else {
+							building->removeAccessFee();
+							creature->sendSystemMessage("Access fee removed");
+						}
+					}
+				}
 				break;
 			case 50:
 				structureManager->promptNameStructure(creature, structureObject, nullptr);
-				break;
-			case 124:
-				creature->executeObjectControllerAction(0x13F7E585, structureObject->getObjectID(), ""); //structureStatus
+				// creature->executeObjectControllerAction(0xC367B461, structureObject->getObjectID(), ""); // nameStructure
 				break;
 			case 69:
 				structureManager->promptSelectSign(structureObject, creature);
 				break;
-			}
-		}
+			case 131: // Assign Droid
+				structureManager->promptMaintenanceDroid(structureObject, creature);
+				break;
 
-		return 0;
-	}
-
-	if (structureObject->isOnAdminList(creature)) {
-
-		StructureManager* structureManager = StructureManager::instance();
-
-		Locker structureLocker(structureObject, creature);
-
-		switch (selectedID) {
-		case 201:
-			structureManager->promptDeleteAllItems(creature, structureObject);
-			break;
-		case 202:
-			structureManager->promptFindLostItems(creature, structureObject);
-			break;
-		case 121:
-			structureObject->sendPermissionListTo(creature, "ADMIN");
-			break;
-		case 119:
-			structureObject->sendPermissionListTo(creature, "ENTRY");
-			break;
-		case 120:
-			structureObject->sendPermissionListTo(creature, "BAN");
-			break;
-		case 122:
-			structureObject->sendPermissionListTo(creature, "VENDOR");
-			break;
-		case 128:
-			creature->executeObjectControllerAction(0x18FC1726, structureObject->getObjectID(), ""); //destroyStructure
-			break;
-		case 129:
-			creature->executeObjectControllerAction(0xE7E35B30, structureObject->getObjectID(), ""); //payMaintenance
-			break;
-		case 70:
-			structureManager->promptWithdrawMaintenance(structureObject, creature);
-			break;
-		case 124:
-			creature->executeObjectControllerAction(0x13F7E585, structureObject->getObjectID(), ""); //structureStatus
-			break;
-		case 127:
-			creature->executeObjectControllerAction(0xF59E3CE1, structureObject->getObjectID(), ""); //declareResidence
-			break;
-		case 125:
-			creature->executeObjectControllerAction(0x786CC38E, structureObject->getObjectID(), ""); //setPrivacy
-			break;
-		case 68:
-			if(structureObject->isBuildingObject()) {
-				BuildingObject* building = cast<BuildingObject*>(structureObject.get());
-				if(!building->hasAccessFee()) {
-
-					if(!building->canChangeAccessFee()) {
-						StringIdChatParameter param("@player_structure:turnstile_wait");
-						param.setDI(building->getAccessFeeDelay());
-						creature->sendSystemMessage(param);
-						return 0;
+			// NEW: Pack Up House (non-civic only)
+			case RADIAL_PACK_UP_HOUSE: {
+				if (structureObject->isBuildingObject() && !structureObject->isCivicStructure()) {
+					BuildingObject* building = cast<BuildingObject*>(structureObject.get());
+					if (building != nullptr) {
+						if (!HousePackupManager::instance()->packUpHouse(building, creature)) {
+							creature->sendSystemMessage("Pack up failed.");
+						}
 					}
-
-					ManagedReference<StructureSetAccessFeeSession*> session = new StructureSetAccessFeeSession(creature, building);
-					if(session->initializeSession() == 1) {
-						creature->addActiveSession(SessionFacadeType::SETSTRUCTUREACCESSFEE, session);
-						session->promptSetAccessFee();
-					}
-				} else {
-					building->removeAccessFee();
-					creature->sendSystemMessage("Access fee removed");
 				}
+				break;
 			}
-			break;
-		case 50:
-			structureManager->promptNameStructure(creature, structureObject, nullptr);
-			//creature->executeObjectControllerAction(0xC367B461, structureObject->getObjectID(), ""); //nameStructure
-			break;
-		case 69:
-			structureManager->promptSelectSign(structureObject, creature);
-			break;
-		case 131: // Assign Droid
-			structureManager->promptMaintenanceDroid(structureObject,creature);
-			break;
-		}
 
+			default:
+				break;
+		}
 	}
 
-	if(selectedID == 130 && (structureObject->isOnAdminList(creature) || structureObject->isOnPermissionList("VENDOR", creature))) {
+	// Vendor creation (admin or vendor permission)
+	if (selectedID == 130 && (structureObject->isOnAdminList(creature) || structureObject->isOnPermissionList("VENDOR", creature))) {
 		if (creature->hasSkill("crafting_artisan_business_03")) {
 			creature->executeObjectControllerAction(STRING_HASHCODE("createvendor")); // Create Vendor
 		}
 	}
-
 
 	return 0;
 }


### PR DESCRIPTION
- Updated `destroyStructure` method in `StructureManager` to include an option for refunding lots when a structure is destroyed.
- Modified `DestroyStructureTask` to handle the new refundLots parameter and implement the refund logic.
- Integrated `HousePackupManager` to manage lot releases and restore packed house contents when placing structures.
- Added a new radial menu option for players to pack up their houses, allowing for better management of building objects.
- Adjusted `PlayerObjectImplementation` to account for lots consumed by packed deeds in inventory.
- Enhanced `StructureTerminalMenuComponent` to include options for managing house packing and maintenance droids.