### PR TITLE
Enhance structure permissions handling for civic structures

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/installation/factory/FactoryObjectImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/installation/factory/FactoryObjectImplementation.cpp
@@ -134,6 +134,19 @@ void FactoryObjectImplementation::createChildObjects() {
 void FactoryObjectImplementation::fillAttributeList(AttributeListMessage* alm, CreatureObject* object) {
 	InstallationObjectImplementation::fillAttributeList(alm, object);
 
+	// Show maintenance and power to admins
+	if (object != nullptr && isOnAdminList(object)) {
+		alm->insertAttribute("examine_maintenance_rate", String::valueOf((int)getMaintenanceRate()) + " / hour");
+		alm->insertAttribute("examine_maintenance", String::valueOf((int)surplusMaintenance));
+
+		int basePowerRate = getBasePowerRate();
+		if (basePowerRate > 0) {
+			alm->insertAttribute("examine_power", String::valueOf((int)surplusPower) + " (Rate: " + String::valueOf(basePowerRate) + " / hour)");
+		} else {
+			alm->insertAttribute("examine_power", String::valueOf((int)surplusPower));
+		}
+	}
+
 	if (isActive() && object != nullptr && isOnAdminList(object)) {
 		if (getContainerObjectsSize() == 0)
 			return;

--- a/MMOCoreORB/src/server/zone/objects/structure/StructureObject.idl
+++ b/MMOCoreORB/src/server/zone/objects/structure/StructureObject.idl
@@ -245,13 +245,7 @@ class StructureObject extends TangibleObject {
 	}
 
 	@dirty
-	public void sendPermissionListTo(CreatureObject creature, final string listName) {
-		// Ensure the permission list exists (for civic structures that may not have them initialized)
-		if (!structurePermissionList.containsList(listName)) {
-			structurePermissionList.addList(listName);
-		}
-		structurePermissionList.sendTo(creature, listName);
-	}
+	public native void sendPermissionListTo(CreatureObject creature, final string listName);
 
 	@read
 	public boolean hasPermissionList(final string listName) {
@@ -263,37 +257,20 @@ class StructureObject extends TangibleObject {
 		return structurePermissionList.isListFull(listName);
 	}
 
-	public int togglePermission(final string listName, final unsigned long objectID) {
-		// Ensure the permission list exists (for civic structures that may not have them initialized)
-		if (!structurePermissionList.containsList(listName)) {
-			structurePermissionList.addList(listName);
-		}
-		return structurePermissionList.togglePermission(listName, objectID);
-	}
+	@dirty
+	public native int togglePermission(final string listName, final unsigned long objectID);
 
-	public int grantPermission(final string listName, final unsigned long objectID) {
-		// Ensure the permission list exists (for civic structures that may not have them initialized)
-		if (!structurePermissionList.containsList(listName)) {
-			structurePermissionList.addList(listName);
-		}
-		return structurePermissionList.grantPermission(listName, objectID);
-	}
+	@dirty
+	public native int grantPermission(final string listName, final unsigned long objectID);
 
-	public int revokePermission(final string listName, final unsigned long objectID) {
-		// Ensure the permission list exists (for civic structures that may not have them initialized)
-		if (!structurePermissionList.containsList(listName)) {
-			structurePermissionList.addList(listName);
-		}
-		return structurePermissionList.revokePermission(listName, objectID);
-	}
+	@dirty
+	public native int revokePermission(final string listName, final unsigned long objectID);
 
-	public int revokeAllPermissions(final unsigned long objectID) {
-		return structurePermissionList.revokeAllPermissions(objectID);
-	}
+	@dirty
+	public native int revokeAllPermissions(final unsigned long objectID);
 
-	public void revokeAllPermissions() {
-		structurePermissionList.revokeAllPermissions();
-	}
+	@dirty
+	public native void revokeAllPermissions();
 
 	/**
 	 * Returns the cost to redeed this building. The redeed cost is 50 times the hourly maintenance rate.

--- a/MMOCoreORB/src/server/zone/objects/structure/StructureObject.idl
+++ b/MMOCoreORB/src/server/zone/objects/structure/StructureObject.idl
@@ -246,6 +246,10 @@ class StructureObject extends TangibleObject {
 
 	@dirty
 	public void sendPermissionListTo(CreatureObject creature, final string listName) {
+		// Ensure the permission list exists (for civic structures that may not have them initialized)
+		if (!structurePermissionList.containsList(listName)) {
+			structurePermissionList.addList(listName);
+		}
 		structurePermissionList.sendTo(creature, listName);
 	}
 
@@ -260,14 +264,26 @@ class StructureObject extends TangibleObject {
 	}
 
 	public int togglePermission(final string listName, final unsigned long objectID) {
+		// Ensure the permission list exists (for civic structures that may not have them initialized)
+		if (!structurePermissionList.containsList(listName)) {
+			structurePermissionList.addList(listName);
+		}
 		return structurePermissionList.togglePermission(listName, objectID);
 	}
 
 	public int grantPermission(final string listName, final unsigned long objectID) {
+		// Ensure the permission list exists (for civic structures that may not have them initialized)
+		if (!structurePermissionList.containsList(listName)) {
+			structurePermissionList.addList(listName);
+		}
 		return structurePermissionList.grantPermission(listName, objectID);
 	}
 
 	public int revokePermission(final string listName, final unsigned long objectID) {
+		// Ensure the permission list exists (for civic structures that may not have them initialized)
+		if (!structurePermissionList.containsList(listName)) {
+			structurePermissionList.addList(listName);
+		}
 		return structurePermissionList.revokePermission(listName, objectID);
 	}
 

--- a/MMOCoreORB/src/server/zone/objects/structure/StructureObjectImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/structure/StructureObjectImplementation.cpp
@@ -14,6 +14,7 @@
 #include "server/zone/objects/player/PlayerObject.h"
 #include "server/zone/objects/guild/GuildObject.h"
 #include "server/zone/objects/tangible/terminal/guild/GuildTerminal.h"
+#include "server/zone/objects/region/CityRegion.h"
 
 #include "templates/tangible/SharedStructureObjectTemplate.h"
 #include "server/zone/managers/city/PayPropertyTaxTask.h"
@@ -814,7 +815,15 @@ bool StructureObjectImplementation::isOnAdminList(CreatureObject* player) const 
 
 	if (ghost != nullptr && ghost->isPrivileged())
 		return true;
-	else if (structurePermissionList.isOnPermissionList("ADMIN", player->getObjectID())) {
+
+	// Check if this is a civic structure and the player is the mayor
+	if (isCivicStructure()) {
+		ManagedReference<CityRegion*> city = const_cast<ManagedWeakReference<CityRegion*>&>(cityRegion).get();
+		if (city != nullptr && city->isMayor(player->getObjectID()))
+			return true;
+	}
+
+	if (structurePermissionList.isOnPermissionList("ADMIN", player->getObjectID())) {
 		return true;
 	} else {
 		ManagedReference<GuildObject*> guild = player->getGuildObject().get();

--- a/MMOCoreORB/src/server/zone/objects/structure/StructureObjectImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/structure/StructureObjectImplementation.cpp
@@ -172,9 +172,8 @@ void StructureObjectImplementation::notifyInsertToZone(Zone* zone) {
 	TangibleObjectImplementation::notifyInsertToZone(zone);
 
 	if (isCivicStructure()) {
-		if (structurePermissionList.containsList("ADMIN"))
-			structurePermissionList.dropList("ADMIN");
-
+		// Drop permission lists that civic structures don't use
+		// Keep ADMIN and VENDOR lists for city halls
 		if (structurePermissionList.containsList("ENTRY"))
 			structurePermissionList.dropList("ENTRY");
 
@@ -183,9 +182,6 @@ void StructureObjectImplementation::notifyInsertToZone(Zone* zone) {
 
 		if (structurePermissionList.containsList("BAN"))
 			structurePermissionList.dropList("BAN");
-
-		if (structurePermissionList.containsList("VENDOR"))
-			structurePermissionList.dropList("VENDOR");
 	}
 
 	if (!staticObject && getBaseMaintenanceRate() != 0 && !isTurret() && !isMinefield() && !isScanner()) {
@@ -910,4 +906,44 @@ bool StructureObjectImplementation::isOnPermissionList(const String& listName, C
 	}
 
 	return false;
+}
+
+void StructureObjectImplementation::sendPermissionListTo(CreatureObject* creature, const String& listName) {
+	// Ensure the permission list exists (for civic structures that may not have them initialized)
+	if (!structurePermissionList.containsList(listName)) {
+		structurePermissionList.addList(listName);
+	}
+	structurePermissionList.sendTo(creature, listName);
+}
+
+int StructureObjectImplementation::togglePermission(const String& listName, uint64 objectID) {
+	// Ensure the permission list exists (for civic structures that may not have them initialized)
+	if (!structurePermissionList.containsList(listName)) {
+		structurePermissionList.addList(listName);
+	}
+	return structurePermissionList.togglePermission(listName, objectID);
+}
+
+int StructureObjectImplementation::grantPermission(const String& listName, uint64 objectID) {
+	// Ensure the permission list exists (for civic structures that may not have them initialized)
+	if (!structurePermissionList.containsList(listName)) {
+		structurePermissionList.addList(listName);
+	}
+	return structurePermissionList.grantPermission(listName, objectID);
+}
+
+int StructureObjectImplementation::revokePermission(const String& listName, uint64 objectID) {
+	// Ensure the permission list exists (for civic structures that may not have them initialized)
+	if (!structurePermissionList.containsList(listName)) {
+		structurePermissionList.addList(listName);
+	}
+	return structurePermissionList.revokePermission(listName, objectID);
+}
+
+int StructureObjectImplementation::revokeAllPermissions(uint64 objectID) {
+	return structurePermissionList.revokeAllPermissions(objectID);
+}
+
+void StructureObjectImplementation::revokeAllPermissions() {
+	structurePermissionList.revokeAllPermissions();
 }

--- a/MMOCoreORB/src/server/zone/objects/tangible/terminal/components/StructureTerminalMenuComponent.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/terminal/components/StructureTerminalMenuComponent.cpp
@@ -67,6 +67,15 @@ void StructureTerminalMenuComponent::fillObjectMenuResponse(SceneObject* sceneOb
 				if (building != nullptr && building->getSignObject() != nullptr)
 					menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 69, 3, "@player_structure:management_change_sign"); // Change Sign
 			}
+
+			// Permissions submenu for civic structures (city halls)
+			menuResponse->addRadialMenuItem(RADIAL_ROOT_PERMISSIONS, 3, "@player_structure:permissions"); // Structure Permissions
+			menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_PERMISSIONS, 121, 3, "@player_structure:permission_admin");  // Administrator List
+
+			if (structureObject->isBuildingObject()) {
+				menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_PERMISSIONS, 122, 3, "@player_structure:permission_vendor"); // Vendor List
+				// Note: Entry list (119) and Ban list (120) intentionally omitted for civic structures
+			}
 		}
 		return;
 	}
@@ -190,6 +199,12 @@ int StructureTerminalMenuComponent::handleObjectMenuSelect(SceneObject* sceneObj
 					break;
 				case 69:
 					structureManager->promptSelectSign(structureObject, creature);
+					break;
+				case 121:
+					structureObject->sendPermissionListTo(creature, "ADMIN");
+					break;
+				case 122:
+					structureObject->sendPermissionListTo(creature, "VENDOR");
 					break;
 				default:
 					break;


### PR DESCRIPTION
- Added checks to ensure permission lists are initialized before use in sendPermissionListTo, togglePermission, grantPermission, and revokePermission methods.
- Updated StructureTerminalMenuComponent to include permissions submenu for civic structures, allowing access to admin and vendor permission lists.