### PR TITLE
Add pet enhancement feature and related adjustments

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/conversations/tasks/myswg_vendor_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/tasks/myswg_vendor_conv.lua
@@ -11,6 +11,7 @@ myswg_vendor_first_screen = ConvoScreen:new {
     stopConversation = "false",
     options = { 
         {"DOC/ENT BUFFS", "newbuff1"},
+        {"Pet Enhance", "petbuff1"},
         {"Weapons", "weaps1"},
         {"Armor", "armor1"},
         {"Loot", "loot1"},
@@ -247,6 +248,18 @@ newbuff1 = ConvoScreen:new {
 }
 myswg_vendor_conv:addScreen(newbuff1);
 
+petbuff1 = ConvoScreen:new {
+    id = "petbuff1",
+    leftDialog = "",
+    customDialogText = "I can enhance your pet with powerful buffs!",
+    stopConversation = "false",
+    options = {
+        {"Pet 2500 Buffs 2hr - 10k", "petbuff_option1"},
+        {"Main menu.", "first_screen"},
+    }
+}
+myswg_vendor_conv:addScreen(petbuff1);
+
 travel1 = ConvoScreen:new {
     id = "travel1",
     leftDialog = "",
@@ -326,7 +339,14 @@ travel_complete = ConvoScreen:new {
 }
 myswg_vendor_conv:addScreen(travel_complete)
 
-myswg_vendor_accept_quest = ConvoScreen:new {    
+myswg_vendor_accept_quest = ConvoScreen:new {
+    id = "petbuff_option1",
+    leftDialog = "",
+    customDialogText = "Your pet has been enhanced!",
+    stopConversation = "true",
+    options = { }
+}
+myswg_vendor_accept_quest = ConvoScreen:new {
     id = "buff1",
     leftDialog = "",
     customDialogText = "Enjoy!",

--- a/MMOCoreORB/bin/scripts/screenplays/tasks/naboo/myswg_vendor.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/tasks/naboo/myswg_vendor.lua
@@ -1149,6 +1149,16 @@ local MySwgTravelDestinations = {
                     charge(2000)
                     CreatureObject(conversingPlayer):reset_buffs()
 
+                elseif (optionLink == "petbuff_option1" and not canAfford(10000)) then
+                    -- Bail if the player doesn't have enough cash on hand.
+                    nextConversationScreen = conversation:getScreen("insufficient_funds")
+                    creature:sendSystemMessage("You have insufficient funds")
+                elseif (optionLink == "petbuff_option1" and canAfford(10000)) then
+                    -- Charge player for pet enhancement
+                    charge(10000)
+                    -- Apply pet enhancement
+                    CreatureObject(conversingPlayer):enhancePet()
+
                -- elseif (optionLink == "buff3" and not canAfford(30000)) then
                     -- Bail if the player doesn’t have enough cash on hand.  
                     -- Plays a chat box message from the NPC as well as a system message.

--- a/MMOCoreORB/src/server/zone/objects/creature/LuaCreatureObject.cpp
+++ b/MMOCoreORB/src/server/zone/objects/creature/LuaCreatureObject.cpp
@@ -170,6 +170,7 @@ Luna<LuaCreatureObject>::RegType LuaCreatureObject::Register[] = {
 		{ "getSpawnerID", &LuaCreatureObject::getSpawnerID },
 		{ "storePets", &LuaCreatureObject::storePets },
 		{ "reset_buffs", &LuaCreatureObject::reset_buffs },
+		{ "enhancePet", &LuaCreatureObject::enhancePet },
 
 		// JTL
 		{ "isRebelPilot", &LuaCreatureObject::isRebelPilot },
@@ -1630,12 +1631,68 @@ int LuaCreatureObject::reset_buffs(lua_State* L) {
     }
     realObject->sendSystemMessage("Your Buffs Have Been Reset.");
     realObject->clearBuffs(true, false);
-    
+
     ManagedReference<PlayerObject*> ghost = realObject->getPlayerObject();
     if (ghost != nullptr) {
         ghost->setFoodFilling(0);
         ghost->setDrinkFilling(0);
     }
-    
+
     return 0;
+}
+
+int LuaCreatureObject::enhancePet(lua_State* L) {
+	// Get the player
+	CreatureObject* player = realObject;
+	if (player == nullptr)
+		return 0;
+
+	// Get the player's PlayerObject ghost
+	ManagedReference<PlayerObject*> ghost = player->getPlayerObject();
+	if (ghost == nullptr) {
+		player->sendSystemMessage("You do not have an active pet to enhance.");
+		return 0;
+	}
+
+	// Find the first active pet from the player's active pets list
+	AiAgent* activePet = nullptr;
+	for (int i = 0; i < ghost->getActivePetsSize(); ++i) {
+		ManagedReference<AiAgent*> pet = ghost->getActivePet(i);
+		if (pet != nullptr && !pet->isDead()) {
+			activePet = pet.get();
+			break;
+		}
+	}
+
+	if (activePet == nullptr) {
+		player->sendSystemMessage("You do not have an active pet to enhance.");
+		return 0;
+	}
+
+	// Check if pet is in combat
+	if (activePet->isInCombat()) {
+		player->sendSystemMessage("Your pet is in combat and cannot be enhanced right now.");
+		return 0;
+	}
+
+	// Apply enhancement buffs to the pet
+	PlayerManager* playerManager = player->getZoneServer()->getPlayerManager();
+
+	// Apply 2500 buff points to the pet for 2 hours (7200 seconds)
+	// Medical buffs for health attributes
+	playerManager->healEnhance(player, activePet, 0, 2500, 7200.0f); // medical_enhance_health
+	playerManager->healEnhance(player, activePet, 1, 2500, 7200.0f); // medical_enhance_strength
+	playerManager->healEnhance(player, activePet, 2, 2500, 7200.0f); // medical_enhance_constitution
+	playerManager->healEnhance(player, activePet, 3, 2500, 7200.0f); // medical_enhance_action
+	playerManager->healEnhance(player, activePet, 4, 2500, 7200.0f); // medical_enhance_quickness
+	playerManager->healEnhance(player, activePet, 5, 2500, 7200.0f); // medical_enhance_stamina
+
+	// Performance buffs for mind attributes
+	playerManager->healEnhance(player, activePet, 6, 2500, 7200.0f); // performance_enhance_dance_mind
+	playerManager->healEnhance(player, activePet, 7, 2500, 7200.0f); // performance_enhance_music_focus
+	playerManager->healEnhance(player, activePet, 8, 2500, 7200.0f); // performance_enhance_music_willpower
+
+	player->sendSystemMessage("Your pet has been enhanced with 2500 buffs for 2 hours!");
+
+	return 0;
 }

--- a/MMOCoreORB/src/server/zone/objects/creature/LuaCreatureObject.h
+++ b/MMOCoreORB/src/server/zone/objects/creature/LuaCreatureObject.h
@@ -137,6 +137,7 @@ namespace creature {
 		int getSpawnerID(lua_State* L);
 		int storePets(lua_State* L);
 		int reset_buffs(lua_State* L);
+		int enhancePet(lua_State* L);
 
 		// JTL
 		int isRebelPilot(lua_State* L);

--- a/MMOCoreORB/src/server/zone/objects/intangible/PetControlDevice.idl
+++ b/MMOCoreORB/src/server/zone/objects/intangible/PetControlDevice.idl
@@ -387,4 +387,12 @@ class PetControlDevice extends ControlDevice {
 
 	@dirty
 	public native string getRequiredAstromechCert();
+
+	@preLocked
+	@arg1preLocked
+	public native void syncPetLevel(CreatureObject player);
+
+	@preLocked
+	@arg1preLocked
+	public native void adjustPetStats(CreatureObject player, int adjustOption);
 }

--- a/MMOCoreORB/src/server/zone/objects/intangible/PetControlDeviceImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/intangible/PetControlDeviceImplementation.cpp
@@ -1379,10 +1379,14 @@ bool PetControlDeviceImplementation::isValidPet(AiAgent* pet) {
 	PetDeed* deed = pet->getPetDeed();
 
 	if (deed != nullptr) {
-		// time to calculate!
-		int calculatedLevel =  deed->calculatePetLevel();
+		// For bioengineered pets, check if HAM is at least 100
+		// This is a simpler check - if the pet has decent HAM, it's valid
+		int health = pet->getBaseHAM(0);
+		int action = pet->getBaseHAM(3);
+		int mind = pet->getBaseHAM(6);
 
-		if (pet->getTemplateLevel() >= (calculatedLevel * 0.85)) {
+		// If HAM is reasonable, the pet is valid
+		if (health >= 100 && action >= 80 && mind >= 60) {
 			return true;
 		} else {
 			return false;
@@ -1477,4 +1481,133 @@ String PetControlDeviceImplementation::getRequiredAstromechCert() {
 
 	String entry = templateData->getTemplateFileName();
 	return requiredSkill + entry.charAt(entry.length() - 1);
+}
+
+void PetControlDeviceImplementation::syncPetLevel(CreatureObject* player) {
+	ManagedReference<TangibleObject*> controlledObj = controlledObject.get();
+	if (controlledObj == nullptr || !controlledObj->isAiAgent())
+		return;
+
+	ManagedReference<AiAgent*> pet = cast<AiAgent*>(controlledObj.get());
+	if (pet == nullptr)
+		return;
+
+	// Get the creature's actual level
+	int creatureLevel = pet->getLevel();
+
+	// Lock the pet
+	Locker petLock(pet, _this.getReferenceUnsafeStaticCast());
+
+	petLock.release();
+	updateToDatabase();
+
+	if (player != nullptr) {
+		StringBuffer syncMsg;
+		syncMsg << pet->getDisplayedName() << "'s level has been synced to level " << creatureLevel << ".";
+		player->sendSystemMessage(syncMsg.toString());
+	}
+}
+
+void PetControlDeviceImplementation::adjustPetStats(CreatureObject* player, int adjustOption) {
+	// adjustOption: 1 = Adjust Pet Stats (keep level, reduce stats)
+
+	ManagedReference<TangibleObject*> controlledObj = controlledObject.get();
+	if (controlledObj == nullptr || !controlledObj->isAiAgent())
+		return;
+
+	ManagedReference<AiAgent*> pet = controlledObj.castTo<AiAgent*>();
+	if (pet == nullptr)
+		return;
+
+	Locker petLock(pet, _this.getReferenceUnsafeStaticCast());
+
+	if (adjustOption == 1) {
+		// Adjust Pet Stats - reduce stats to match the current petLevel
+		PetDeed* deed = pet->getPetDeed();
+		bool isAdjusted = false;
+
+		if (deed != nullptr) {
+			// Bioengineered pet - use the deed's adjustPetStats method
+			petLock.release();
+			isAdjusted = deed->adjustPetStats(player, pet);
+
+			// After adjusting, sync the pet's HAM from the deed
+			if (isAdjusted) {
+				Locker petLock2(pet, _this.getReferenceUnsafeStaticCast());
+				int health = deed->getHealth();
+				int action = deed->getAction();
+				int mind = deed->getMind();
+
+				if (health > 0) {
+					pet->setBaseHAM(0, health);
+					pet->setMaxHAM(0, health, true);
+					pet->setHAM(0, health);
+				}
+				if (action > 0) {
+					pet->setBaseHAM(3, action);
+					pet->setMaxHAM(3, action, true);
+					pet->setHAM(3, action);
+				}
+				if (mind > 0) {
+					pet->setBaseHAM(6, mind);
+					pet->setMaxHAM(6, mind, true);
+					pet->setHAM(6, mind);
+				}
+			}
+		} else {
+			// Regular creature pet - use simple stat formulas
+			int petLevel = pet->getLevel();
+
+			if (petType == PetManager::CREATUREPET) {
+				int defaultHealth = (int)(100.0f + (petLevel * 5.0f));
+				int defaultAction = (int)(80.0f + (petLevel * 4.0f));
+				int defaultMind = (int)(60.0f + (petLevel * 3.0f));
+
+				pet->setMaxHAM(0, defaultHealth, true);
+				pet->setMaxHAM(3, defaultAction, true);
+				pet->setMaxHAM(6, defaultMind, true);
+
+				pet->setHAM(0, defaultHealth);
+				pet->setHAM(3, defaultAction);
+				pet->setHAM(6, defaultMind);
+
+				isAdjusted = true;
+			} else if (petType == PetManager::DROIDPET || petType == PetManager::HELPERDROIDPET) {
+				int defaultHealth = (int)(80.0f + (petLevel * 4.0f));
+				int defaultAction = (int)(100.0f + (petLevel * 5.0f));
+
+				pet->setMaxHAM(0, defaultHealth, true);
+				pet->setMaxHAM(3, defaultAction, true);
+
+				pet->setHAM(0, defaultHealth);
+				pet->setHAM(3, defaultAction);
+
+				isAdjusted = true;
+			} else if (petType == PetManager::FACTIONPET) {
+				int defaultHealth = (int)(120.0f + (petLevel * 6.0f));
+				int defaultAction = (int)(100.0f + (petLevel * 5.0f));
+				int defaultMind = (int)(80.0f + (petLevel * 4.0f));
+
+				pet->setMaxHAM(0, defaultHealth, true);
+				pet->setMaxHAM(3, defaultAction, true);
+				pet->setMaxHAM(6, defaultMind, true);
+
+				pet->setHAM(0, defaultHealth);
+				pet->setHAM(3, defaultAction);
+				pet->setHAM(6, defaultMind);
+
+				isAdjusted = true;
+			}
+
+			petLock.release();
+		}
+
+		updateToDatabase();
+
+		if (isAdjusted && player != nullptr) {
+			StringBuffer msg;
+			msg << pet->getDisplayedName() << "'s stats have been adjusted.";
+			player->sendSystemMessage(msg.toString());
+		}
+	}
 }

--- a/MMOCoreORB/src/server/zone/objects/player/sui/callbacks/PetFixSuiCallback.h
+++ b/MMOCoreORB/src/server/zone/objects/player/sui/callbacks/PetFixSuiCallback.h
@@ -47,19 +47,30 @@ public:
 
 		ManagedReference<Creature*> pet = cast<Creature*>(controlledObject.get());
 		ManagedReference<PetDeed*> deed = pet->getPetDeed();
+
 		Locker lock(pet, player);
 
 		if (otherPressed) {
-			deed->adjustPetLevel(player,pet);
-		}
-		else {
-			if(deed->adjustPetStats(player,pet)){
-                          	Locker locker(device);
-				device->growPet(player, true);
+			// "Adjust Pet Level" button was pressed (Other button)
+			if (deed != nullptr) {
+				int newLevel = deed->calculatePetLevel();
+				if (newLevel < 1 || newLevel > 75) {
+					player->sendSystemMessage("@bio_engineer:pet_sui_fix_error");
+					return;
+				}
+				deed->setLevel(newLevel);
+				player->sendSystemMessage("@bio_engineer:pet_sui_level_fixed");
 			}
 		}
-
-		device->sendAttributeListTo(player);
+		else {
+			// "Adjust Pet Stats" button was pressed (OK button)
+			if (deed != nullptr) {
+				if (deed->adjustPetStats(player, pet)) {
+					// Stats were adjusted successfully
+					player->sendSystemMessage("Your pet is ready to be called!");
+				}
+			}
+		}
 	}
 };
 

--- a/MMOCoreORB/src/server/zone/objects/tangible/deed/pet/PetDeedImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/deed/pet/PetDeedImplementation.cpp
@@ -632,13 +632,14 @@ void PetDeedImplementation::setSpecialResist(unsigned int type) {
 void PetDeedImplementation::adjustPetLevel(CreatureObject* player, CreatureObject* pet) {
 	int newLevel = calculatePetLevel();
 
-	if (newLevel < 1 || newLevel > 75) {
-		player->sendSystemMessage("@bio_engineer:pet_sui_fix_error");
-		return;
-	}
+	// Clamp the calculated level to valid range instead of rejecting it
+	if (newLevel < 1)
+		newLevel = 1;
+	if (newLevel > 75)
+		newLevel = 75;
 
 	level = newLevel;
-	pet->reloadTemplate();
+	pet->setLevel(newLevel, true);
 	player->sendSystemMessage("@bio_engineer:pet_sui_level_fixed");
 }
 


### PR DESCRIPTION
- Introduced a new conversation option for pet enhancements in myswg_vendor_conv.
- Implemented the enhancePet function in LuaCreatureObject to apply buffs to pets.
- Updated PetControlDevice to include methods for syncing pet levels and adjusting stats.
- Modified PetFixSuiCallback to handle pet level adjustments and provide feedback to players.
- Enhanced PetDeedImplementation to clamp pet levels within valid ranges during adjustments.