### PR TITLE
Add waypoint color management functionality

### DIFF
--- a/MMOCoreORB/bin/scripts/commands/waypointcolor.lua
+++ b/MMOCoreORB/bin/scripts/commands/waypointcolor.lua
@@ -1,0 +1,49 @@
+--Copyright (C) 2010 <SWGEmu>
+
+--This File is part of Core3.
+
+--This program is free software; you can redistribute
+--it and/or modify it under the terms of the GNU Lesser
+--General Public License as published by the Free Software
+--Foundation; either version 2 of the License,
+--or (at your option) any later version.
+
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+--See the GNU Lesser General Public License for
+--more details.
+
+--You should have received a copy of the GNU Lesser General
+--Public License along with this program; if not, write to
+--the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+--Linking Engine3 statically or dynamically with other modules
+--is making a combined work based on Engine3.
+--Thus, the terms and conditions of the GNU Lesser General Public License
+--cover the whole combination.
+
+--In addition, as a special exception, the copyright holders of Engine3
+--give you permission to combine Engine3 program with free software
+--programs or libraries that are released under the GNU LGPL and with
+--code included in the standard release of Core3 under the GNU LGPL
+--license (or modified versions of such code, with unchanged license).
+--You may copy and distribute such a system following the terms of the
+--GNU LGPL for Engine3 and the licenses of the other code concerned,
+--provided that you include the source code of that other code when
+--and as the GNU LGPL requires distribution of source code.
+
+--Note that people who make modified versions of Engine3 are not obligated
+--to grant this special exception for their modified versions;
+--it is their choice whether to do so. The GNU Lesser General Public License
+--gives permission to release a modified version without this exception;
+--this exception also makes it possible to release a modified version
+
+
+WaypointcolorCommand = {
+	name = "waypointcolor",
+	addToCombatQueue = false,
+	called = false
+}
+
+AddCommand(WaypointcolorCommand)

--- a/MMOCoreORB/bin/scripts/object/tangible/datapad/character_datapad.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/datapad/character_datapad.lua
@@ -42,7 +42,7 @@
 
 
 object_tangible_datapad_character_datapad = object_tangible_datapad_shared_character_datapad:new {
-	objectMenuComponent = "DatapadMenuComponent",
+	
 }
 
 ObjectTemplates:addTemplate(object_tangible_datapad_character_datapad, "object/tangible/datapad/character_datapad.iff")

--- a/MMOCoreORB/bin/scripts/object/tangible/datapad/character_datapad.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/datapad/character_datapad.lua
@@ -42,7 +42,7 @@
 
 
 object_tangible_datapad_character_datapad = object_tangible_datapad_shared_character_datapad:new {
-
+	objectMenuComponent = "DatapadMenuComponent",
 }
 
 ObjectTemplates:addTemplate(object_tangible_datapad_character_datapad, "object/tangible/datapad/character_datapad.iff")

--- a/MMOCoreORB/bin/scripts/object/waypoint/base/waypoint_default.lua
+++ b/MMOCoreORB/bin/scripts/object/waypoint/base/waypoint_default.lua
@@ -42,7 +42,7 @@
 
 
 object_waypoint_base_waypoint_default = object_waypoint_base_shared_waypoint_default:new {
-
+	objectMenuComponent = "WaypointMenuComponent",
 }
 
 ObjectTemplates:addTemplate(object_waypoint_base_waypoint_default, "object/waypoint/base/waypoint_default.iff")

--- a/MMOCoreORB/bin/scripts/object/waypoint/waypoint.lua
+++ b/MMOCoreORB/bin/scripts/object/waypoint/waypoint.lua
@@ -42,7 +42,7 @@
 
 
 object_waypoint_waypoint = object_waypoint_shared_waypoint:new {
-
+	objectMenuComponent = "WaypointMenuComponent",
 }
 
 ObjectTemplates:addTemplate(object_waypoint_waypoint, "object/waypoint/waypoint.iff")

--- a/MMOCoreORB/src/server/zone/managers/components/ComponentManager.cpp
+++ b/MMOCoreORB/src/server/zone/managers/components/ComponentManager.cpp
@@ -55,6 +55,8 @@
 #include "server/zone/objects/tangible/components/CloningTerminalMenuComponent.h"
 #include "server/zone/objects/tangible/components/HolocronMenuComponent.h"
 #include "server/zone/objects/tangible/components/WaypointDatapadMenuComponent.h"
+#include "server/zone/objects/tangible/components/DatapadMenuComponent.h"
+#include "server/zone/objects/waypoint/components/WaypointMenuComponent.h"
 #include "server/zone/objects/tangible/components/ForceCrystalMenuComponent.h"
 #include "server/zone/objects/tangible/components/RobeObjectMenuComponent.h"
 #include "server/zone/objects/tangible/components/generic/ArtCrateMenuComponent.h"
@@ -211,6 +213,8 @@ ComponentManager::ComponentManager() {
 
 	components.put("HolocronMenuComponent", new HolocronMenuComponent());
 	components.put("WaypointDatapadMenuComponent", new WaypointDatapadMenuComponent());
+	components.put("DatapadMenuComponent", new DatapadMenuComponent());
+	components.put("WaypointMenuComponent", new WaypointMenuComponent());
 
 	components.put("AttributeListComponent", new AttributeListComponent());
 	components.put("LootSchematicAttributeListComponent", new LootSchematicAttributeListComponent());

--- a/MMOCoreORB/src/server/zone/managers/objectcontroller/command/CommandConfigManager4.cpp
+++ b/MMOCoreORB/src/server/zone/managers/objectcontroller/command/CommandConfigManager4.cpp
@@ -133,6 +133,7 @@
 #include "server/zone/objects/creature/commands/LaunchIntoSpaceCommand.h"
 #include "server/zone/objects/creature/commands/UnstickCommand.h"
 #include "server/zone/objects/creature/commands/WaypointCommand.h"
+#include "server/zone/objects/creature/commands/WaypointColorCommand.h"
 #include "server/zone/objects/creature/commands/CreateVendorCommand.h"
 #include "server/zone/objects/creature/commands/RequestQuestTimersAndCountersCommand.h"
 #include "server/zone/objects/creature/commands/PilotShipCommand.h"
@@ -280,6 +281,7 @@ void CommandConfigManager::registerCommands4() {
 	commandFactory.registerCommand<LaunchIntoSpaceCommand>(String("launchIntoSpace").toLowerCase());
 	commandFactory.registerCommand<UnstickCommand>(String("unstick").toLowerCase());
 	commandFactory.registerCommand<WaypointCommand>(String("waypoint").toLowerCase());
+	commandFactory.registerCommand<WaypointColorCommand>(String("waypointcolor").toLowerCase());
 	commandFactory.registerCommand<CreateVendorCommand>(String("createVendor").toLowerCase());
 	commandFactory.registerCommand<PilotShipCommand>(String("pilotShip").toLowerCase());
 	commandFactory.registerCommand<UnpilotShipCommand>(String("unpilotShip").toLowerCase());
@@ -303,6 +305,7 @@ void CommandConfigManager::registerCommands4() {
 	commandFactory.registerCommand<DestroyTargetCommand>(String("destroyTarget").toLowerCase());
 	commandFactory.registerCommand<SendFormObjectDataCommand>(String("sendFormObjectData").toLowerCase());
 	commandFactory.registerCommand<WaypointCommand>(String("waypoint").toLowerCase());
+	commandFactory.registerCommand<WaypointColorCommand>(String("waypointcolor").toLowerCase());
 	commandFactory.registerCommand<InspacerepairCommand>(String("inspacerepair").toLowerCase());
 	commandFactory.registerCommand<LightEngineScrambleCommand>(String("lightEngineScramble").toLowerCase());
 	commandFactory.registerCommand<HyperspaceCommand>(String("hyperspace").toLowerCase());

--- a/MMOCoreORB/src/server/zone/managers/radial/RadialManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/radial/RadialManagerImplementation.cpp
@@ -30,6 +30,11 @@ void RadialManagerImplementation::handleObjectMenuRequest(CreatureObject* player
 
 		debug("entering object menu request");
 
+		// Log if this is a waypoint
+		if (menuObject->isWaypointObject()) {
+			Logger::console.info("RadialManager: Processing waypoint menu request", true);
+		}
+
 		menuObject->fillObjectMenuResponse(defaultMenuResponse, player);
 	}
 
@@ -58,6 +63,13 @@ void RadialManagerImplementation::handleObjectMenuSelect(CreatureObject* player,
 	if (selectedObject == nullptr) {
 		player->error() << "RadialManagerImplementation::handleObjectMenuSelect(player=" << player->getObjectID() << ", selectID=" << selectID << ", objectID=" << objectID << "): Failed to get selectedObject from zone server.";
 		return;
+	}
+
+	// Log waypoint selections
+	if (selectedObject->isWaypointObject()) {
+		StringBuffer logMsg;
+		logMsg << "Waypoint radial selection: selectID=" << (int)selectID;
+		Logger::console.info(logMsg.toString(), true);
 	}
 
 	try {

--- a/MMOCoreORB/src/server/zone/objects/creature/commands/WaypointColorCommand.h
+++ b/MMOCoreORB/src/server/zone/objects/creature/commands/WaypointColorCommand.h
@@ -1,0 +1,86 @@
+/*
+ * WaypointColorCommand.h
+ *
+ * Command to change waypoint colors via SUI dialog
+ * Usage: /waypointcolor
+ */
+
+#ifndef WAYPOINTCOLORCOMMAND_H_
+#define WAYPOINTCOLORCOMMAND_H_
+
+#include "server/zone/objects/scene/SceneObject.h"
+#include "server/zone/objects/waypoint/WaypointObject.h"
+#include "server/zone/objects/player/PlayerObject.h"
+#include "server/zone/objects/player/sui/listbox/SuiListBox.h"
+#include "server/zone/objects/player/sui/callbacks/DatapadWaypointListSuiCallback.h"
+
+class WaypointColorCommand : public QueueCommand {
+public:
+	WaypointColorCommand(const String& name, ZoneProcessServer* server) : QueueCommand(name, server) {}
+
+	int doQueueCommand(CreatureObject* creature, const uint64& target, const UnicodeString& arguments) const {
+		if (!checkStateMask(creature)) {
+			return INVALIDSTATE;
+		}
+
+		if (!checkInvalidLocomotions(creature)) {
+			return INVALIDLOCOMOTION;
+		}
+
+		ManagedReference<PlayerObject*> ghost = creature->getPlayerObject();
+
+		if (ghost == nullptr) {
+			return GENERALERROR;
+		}
+
+		// Check if player has any waypoints
+		if (ghost->getWaypointListSize() == 0) {
+			creature->sendSystemMessage("You have no waypoints to manage.");
+			return GENERALERROR;
+		}
+
+		// Create SUI listbox for waypoint selection
+		ManagedReference<SuiListBox*> suiBox = new SuiListBox(creature, SuiWindowType::NONE);
+		suiBox->setPromptTitle("Waypoint Color Manager");
+		suiBox->setPromptText("Select a waypoint to change its color:");
+		suiBox->setForceCloseDistance(32.0f);
+
+		// Add all waypoints to the list
+		for (int i = 0; i < ghost->getWaypointListSize(); i++) {
+			ManagedReference<WaypointObject*> waypoint = ghost->getWaypoint(i);
+			if (waypoint != nullptr) {
+				StringBuffer waypointName;
+				waypointName << waypoint->getCustomObjectName().toString();
+
+				// Add color indicator
+				byte color = waypoint->getColor();
+				String colorName;
+				switch (color) {
+					case 0x00: colorName = " [White]"; break;
+					case 0x01: colorName = " [Blue]"; break;
+					case 0x02: colorName = " [Green]"; break;
+					case 0x03: colorName = " [Orange]"; break;
+					case 0x04: colorName = " [Yellow]"; break;
+					case 0x05: colorName = " [Purple]"; break;
+					case 0x06: colorName = " [White2]"; break;
+					case 0x07: colorName = " [Space]"; break;
+					default: colorName = ""; break;
+				}
+				waypointName << colorName;
+
+				suiBox->addMenuItem(waypointName.toString(), waypoint->getObjectID());
+			}
+		}
+
+		// Set callback
+		suiBox->setCallback(new DatapadWaypointListSuiCallback(creature->getZoneServer()));
+
+		// Add to player's active SUI windows
+		ghost->addSuiBox(suiBox);
+		creature->sendMessage(suiBox->generateMessage());
+
+		return SUCCESS;
+	}
+};
+
+#endif // WAYPOINTCOLORCOMMAND_H_

--- a/MMOCoreORB/src/server/zone/objects/player/sui/callbacks/DatapadWaypointListSuiCallback.h
+++ b/MMOCoreORB/src/server/zone/objects/player/sui/callbacks/DatapadWaypointListSuiCallback.h
@@ -1,0 +1,88 @@
+/*
+ * DatapadWaypointListSuiCallback.h
+ *
+ * Handles the callback when a player selects a waypoint from the datapad management list
+ */
+
+#ifndef DATAPADWAYPOINTLISTSUICALLBACK_H_
+#define DATAPADWAYPOINTLISTSUICALLBACK_H_
+
+#include "server/zone/objects/player/sui/SuiCallback.h"
+#include "server/zone/objects/waypoint/WaypointObject.h"
+#include "server/zone/objects/player/sui/listbox/SuiListBox.h"
+#include "server/zone/objects/player/PlayerObject.h"
+#include "server/zone/objects/player/sui/callbacks/WaypointColorSuiCallback.h"
+
+class DatapadWaypointListSuiCallback : public SuiCallback {
+public:
+	DatapadWaypointListSuiCallback(ZoneServer* serv) : SuiCallback(serv) {
+	}
+
+	void run(CreatureObject* player, SuiBox* suiBox, uint32 eventIndex, Vector<UnicodeString>* args) {
+		bool cancelPressed = (eventIndex == 1);
+
+		if (!suiBox->isListBox() || player == nullptr) {
+			return;
+		}
+
+		if (cancelPressed) {
+			return;
+		}
+
+		if (args->size() < 1) {
+			return;
+		}
+
+		int index = Integer::valueOf(args->get(0).toString());
+
+		SuiListBox* listBox = cast<SuiListBox*>(suiBox);
+
+		if (listBox == nullptr) {
+			return;
+		}
+
+		// Get the selected waypoint ID
+		uint64 waypointID = listBox->getMenuObjectID(index);
+
+		ManagedReference<WaypointObject*> waypoint = server->getObject(waypointID).castTo<WaypointObject*>();
+
+		if (waypoint == nullptr) {
+			player->sendSystemMessage("Unable to find selected waypoint.");
+			return;
+		}
+
+		// Now show the color selection UI for this waypoint
+		ManagedReference<SuiListBox*> colorBox = new SuiListBox(player, SuiWindowType::NONE);
+		colorBox->setPromptTitle("Waypoint Color");
+
+		StringBuffer promptText;
+		promptText << "Select a color for waypoint: " << waypoint->getCustomObjectName().toString();
+		colorBox->setPromptText(promptText.toString());
+
+		colorBox->setUsingObject(waypoint);
+		colorBox->setForceCloseDistance(32.0f);
+
+		// Add color options
+		colorBox->addMenuItem("White", 0x00);
+		colorBox->addMenuItem("Blue", 0x01);
+		colorBox->addMenuItem("Green", 0x02);
+		colorBox->addMenuItem("Orange", 0x03);
+		colorBox->addMenuItem("Yellow", 0x04);
+		colorBox->addMenuItem("Purple", 0x05);
+		colorBox->addMenuItem("White (Alt)", 0x06);
+		colorBox->addMenuItem("Space", 0x07);
+
+		// Set callback
+		colorBox->setCallback(new WaypointColorSuiCallback(server));
+
+		// Add to player's active SUI windows
+		ManagedReference<PlayerObject*> ghost = player->getPlayerObject();
+
+		if (ghost != nullptr) {
+			ghost->addSuiBox(colorBox);
+			player->sendMessage(colorBox->generateMessage());
+		}
+	}
+};
+
+#endif /* DATAPADWAYPOINTLISTSUICALLBACK_H_ */

--- a/MMOCoreORB/src/server/zone/objects/player/sui/callbacks/WaypointColorSuiCallback.h
+++ b/MMOCoreORB/src/server/zone/objects/player/sui/callbacks/WaypointColorSuiCallback.h
@@ -1,0 +1,125 @@
+/*
+ * WaypointColorSuiCallback.h
+ *
+ * Handles the callback when a player selects a waypoint color from the SUI listbox
+ */
+
+#ifndef WAYPOINTCOLORSUICALLBACK_H_
+#define WAYPOINTCOLORSUICALLBACK_H_
+
+#include "server/zone/objects/player/sui/SuiCallback.h"
+#include "server/zone/objects/waypoint/WaypointObject.h"
+#include "server/zone/objects/player/sui/listbox/SuiListBox.h"
+#include "server/zone/objects/player/PlayerObject.h"
+
+class WaypointColorSuiCallback : public SuiCallback {
+public:
+	WaypointColorSuiCallback(ZoneServer* serv) : SuiCallback(serv) {
+	}
+
+	void run(CreatureObject* player, SuiBox* suiBox, uint32 eventIndex, Vector<UnicodeString>* args) {
+		bool cancelPressed = (eventIndex == 1);
+
+		if (!suiBox->isListBox() || player == nullptr) {
+			return;
+		}
+
+		if (cancelPressed) {
+			return;
+		}
+
+		if (args->size() < 1) {
+			return;
+		}
+
+		int index = Integer::valueOf(args->get(0).toString());
+
+		SuiListBox* listBox = cast<SuiListBox*>(suiBox);
+
+		if (listBox == nullptr) {
+			return;
+		}
+
+		ManagedReference<SceneObject*> usingObject = suiBox->getUsingObject().get();
+
+		if (usingObject == nullptr || !usingObject->isWaypointObject()) {
+			player->sendSystemMessage("Unable to change waypoint color.");
+			return;
+		}
+
+		ManagedReference<WaypointObject*> waypoint = usingObject.castTo<WaypointObject*>();
+
+		if (waypoint == nullptr) {
+			player->sendSystemMessage("Unable to change waypoint color.");
+			return;
+		}
+
+		// Get the selected color from the menu item ID
+		uint64 menuObjectID = listBox->getMenuObjectID(index);
+		byte selectedColor = (byte)menuObjectID;
+
+		// Validate color is in range (0x00 to 0x07)
+		if (selectedColor > 0x07) {
+			player->sendSystemMessage("Invalid color selected.");
+			return;
+		}
+
+		Locker wlock(waypoint, player);
+
+		// Set the new color
+		waypoint->setColor(selectedColor);
+
+		// Get the PlayerObject and update the waypoint
+		ManagedReference<PlayerObject*> ghost = player->getPlayerObject();
+
+		if (ghost != nullptr) {
+			// Force an update to the client by toggling the waypoint
+			bool wasActive = waypoint->isActive();
+			ghost->updateWaypoint(waypoint->getObjectID());
+
+			// Restore active state if needed
+			if (wasActive != waypoint->isActive()) {
+				waypoint->setActive(wasActive);
+				ghost->updateWaypoint(waypoint->getObjectID());
+			}
+		}
+
+		// Send confirmation message
+		StringBuffer colorName;
+		switch (selectedColor) {
+			case 0x00: // COLOR_WHITE
+				colorName << "White";
+				break;
+			case 0x01: // COLOR_BLUE
+				colorName << "Blue";
+				break;
+			case 0x02: // COLOR_GREEN
+				colorName << "Green";
+				break;
+			case 0x03: // COLOR_ORANGE
+				colorName << "Orange";
+				break;
+			case 0x04: // COLOR_YELLOW
+				colorName << "Yellow";
+				break;
+			case 0x05: // COLOR_PURPLE
+				colorName << "Purple";
+				break;
+			case 0x06: // COLOR_WHITE2
+				colorName << "White (Alt)";
+				break;
+			case 0x07: // COLOR_SPACE
+				colorName << "Space";
+				break;
+			default:
+				colorName << "Unknown";
+				break;
+		}
+
+		StringBuffer message;
+		message << "Waypoint color changed to " << colorName.toString() << ".";
+		player->sendSystemMessage(message.toString());
+	}
+};
+
+#endif /* WAYPOINTCOLORSUICALLBACK_H_ */

--- a/MMOCoreORB/src/server/zone/objects/tangible/components/DatapadMenuComponent.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/components/DatapadMenuComponent.cpp
@@ -1,0 +1,88 @@
+/*
+ * DatapadMenuComponent.cpp
+ *
+ * Handles radial menu options for datapad objects
+ */
+
+#include "DatapadMenuComponent.h"
+#include "server/zone/objects/creature/CreatureObject.h"
+#include "server/zone/objects/player/PlayerObject.h"
+#include "server/zone/objects/waypoint/WaypointObject.h"
+#include "server/zone/packets/object/ObjectMenuResponse.h"
+#include "server/zone/objects/player/sui/listbox/SuiListBox.h"
+#include "server/zone/objects/player/sui/callbacks/DatapadWaypointListSuiCallback.h"
+
+void DatapadMenuComponent::fillObjectMenuResponse(SceneObject* sceneObject, ObjectMenuResponse* menuResponse, CreatureObject* player) const {
+	if (sceneObject == nullptr || player == nullptr) {
+		return;
+	}
+
+	// Call parent to add default options
+	TangibleObjectMenuComponent::fillObjectMenuResponse(sceneObject, menuResponse, player);
+
+	// Add "Manage Waypoint Colors" option to radial menu (using radial ID 82)
+	menuResponse->addRadialMenuItem(82, 3, "Manage Waypoint Colors");
+}
+
+int DatapadMenuComponent::handleObjectMenuSelect(SceneObject* sceneObject, CreatureObject* player, byte selectedID) const {
+	if (sceneObject == nullptr || player == nullptr) {
+		return 0;
+	}
+
+	// Handle "Manage Waypoint Colors" selection
+	if (selectedID == 82) {
+		ManagedReference<PlayerObject*> ghost = player->getPlayerObject();
+
+		if (ghost == nullptr) {
+			return 0;
+		}
+
+		// Check if player has any waypoints
+		if (ghost->getWaypointListSize() == 0) {
+			player->sendSystemMessage("You have no waypoints to manage.");
+			return 0;
+		}
+
+		// Create SUI listbox for waypoint selection
+		ManagedReference<SuiListBox*> suiBox = new SuiListBox(player, SuiWindowType::NONE);
+		suiBox->setPromptTitle("Waypoint Color Manager");
+		suiBox->setPromptText("Select a waypoint to change its color:");
+		suiBox->setForceCloseDistance(32.0f);
+
+		// Add all waypoints to the list
+		for (int i = 0; i < ghost->getWaypointListSize(); i++) {
+			ManagedReference<WaypointObject*> waypoint = ghost->getWaypoint(i);
+			if (waypoint != nullptr) {
+				StringBuffer waypointName;
+				waypointName << waypoint->getCustomObjectName().toString();
+
+				// Add color indicator
+				byte color = waypoint->getColor();
+				String colorName;
+				switch (color) {
+					case 0x00: colorName = " [White]"; break;
+					case 0x01: colorName = " [Blue]"; break;
+					case 0x02: colorName = " [Green]"; break;
+					case 0x03: colorName = " [Orange]"; break;
+					case 0x04: colorName = " [Yellow]"; break;
+					case 0x05: colorName = " [Purple]"; break;
+					case 0x06: colorName = " [White2]"; break;
+					case 0x07: colorName = " [Space]"; break;
+					default: colorName = ""; break;
+				}
+				waypointName << colorName;
+
+				suiBox->addMenuItem(waypointName.toString(), waypoint->getObjectID());
+			}
+		}
+
+		// Set callback
+		suiBox->setCallback(new DatapadWaypointListSuiCallback(player->getZoneServer()));
+
+		// Add to player's active SUI windows
+		ghost->addSuiBox(suiBox);
+		player->sendMessage(suiBox->generateMessage());
+	}
+
+	return TangibleObjectMenuComponent::handleObjectMenuSelect(sceneObject, player, selectedID);
+}

--- a/MMOCoreORB/src/server/zone/objects/tangible/components/DatapadMenuComponent.h
+++ b/MMOCoreORB/src/server/zone/objects/tangible/components/DatapadMenuComponent.h
@@ -1,0 +1,36 @@
+/*
+ * DatapadMenuComponent.h
+ *
+ * Handles radial menu options for datapad objects
+ */
+
+#ifndef DATAPADMENUCOMPONENT_H_
+#define DATAPADMENUCOMPONENT_H_
+
+#include "TangibleObjectMenuComponent.h"
+
+class DatapadMenuComponent : public TangibleObjectMenuComponent {
+public:
+	/**
+	 * Fills the radial options for datapad objects
+	 * @pre { this object is locked }
+	 * @post { this object is locked, menuResponse is complete}
+	 * @param sceneObject the datapad object
+	 * @param menuResponse ObjectMenuResponse that will be sent to the client
+	 * @param player the player using the object
+	 */
+	virtual void fillObjectMenuResponse(SceneObject* sceneObject, ObjectMenuResponse* menuResponse, CreatureObject* player) const;
+
+	/**
+	 * Handles the radial selection sent by the client
+	 * @pre { this object is locked, player is locked }
+	 * @post { this object is locked, player is locked }
+	 * @param sceneObject the datapad object
+	 * @param player PlayerCreature that selected the option
+	 * @param selectedID selected menu id
+	 * @returns 0 if successful
+	 */
+	virtual int handleObjectMenuSelect(SceneObject* sceneObject, CreatureObject* player, byte selectedID) const;
+};
+
+#endif /* DATAPADMENUCOMPONENT_H_ */

--- a/MMOCoreORB/src/server/zone/objects/waypoint/WaypointObject.idl
+++ b/MMOCoreORB/src/server/zone/objects/waypoint/WaypointObject.idl
@@ -4,6 +4,7 @@ import server.zone.objects.intangible.IntangibleObject;
 import server.zone.objects.creature.CreatureObject;
 import engine.service.proto.BaseMessage;
 include server.zone.packets.scene.AttributeListMessage;
+include server.zone.packets.object.ObjectMenuResponse;
 include templates.SharedObjectTemplate;
 include system.lang.String;
 
@@ -60,6 +61,13 @@ class WaypointObject extends IntangibleObject {
 	@local
 	@dirty
 	public native void fillAttributeList(AttributeListMessage msg, CreatureObject object);
+
+	@local
+	@dirty
+	public native void fillObjectMenuResponse(ObjectMenuResponse menuResponse, CreatureObject player);
+
+	@preLocked
+	public native int handleObjectMenuSelect(CreatureObject player, byte selectedID);
 
 	@preLocked
 	public void setCellID(unsigned int id) {

--- a/MMOCoreORB/src/server/zone/objects/waypoint/components/WaypointMenuComponent.cpp
+++ b/MMOCoreORB/src/server/zone/objects/waypoint/components/WaypointMenuComponent.cpp
@@ -1,85 +1,50 @@
 /*
- * WaypointObjectImplementation.cpp
+ * WaypointMenuComponent.cpp
  *
- *  Created on: 28/12/2009
- *      Author: victor
+ * Handles radial menu options for waypoint objects, including color selection
  */
 
+#include "WaypointMenuComponent.h"
 #include "server/zone/objects/waypoint/WaypointObject.h"
-#include "server/zone/packets/object/ObjectMenuResponse.h"
+#include "server/zone/objects/creature/CreatureObject.h"
 #include "server/zone/objects/player/PlayerObject.h"
+#include "server/zone/packets/object/ObjectMenuResponse.h"
 #include "server/zone/objects/player/sui/listbox/SuiListBox.h"
 #include "server/zone/objects/player/sui/callbacks/WaypointColorSuiCallback.h"
 
-void WaypointObjectImplementation::loadTemplateData(SharedObjectTemplate* templateData) {
-	IntangibleObjectImplementation::loadTemplateData(templateData);
-
-	cellID = 0; //?
-
-	unknown = 0;
-	planetCRC = 0;
-
-	color = COLOR_BLUE;
-	active = 0;
-
-	specialTypeID = 0;
-}
-
-String WaypointObjectImplementation::getDetailedDescription() const {
-	if (detailedDescription.isEmpty())
-		return SceneObjectImplementation::getDetailedDescription();
-
-	return detailedDescription;
-}
-
-void WaypointObjectImplementation::insertToMessage(BaseMessage* msg) {
-	msg->writeInt(cellID); // cellID
-	msg->writeFloat(getPositionX());
-	msg->writeFloat(getPositionZ()); //Z
-	msg->writeFloat(getPositionY());
-	msg->writeLong(unknown); //?
-	msg->writeInt(planetCRC);
-
-	customName.toBinaryStream(msg);
-
-	msg->writeLong(getObjectID());
-	msg->writeByte(color);
-	msg->writeByte(active);
-}
-
-void WaypointObjectImplementation::fillAttributeList(AttributeListMessage* alm, CreatureObject* object) {
-	IntangibleObjectImplementation::fillAttributeList(alm, object);
-
-	if (questDetails.length() > 0)
-		alm->insertAttribute("quest_details", questDetails);
-}
-
-void WaypointObjectImplementation::fillObjectMenuResponse(ObjectMenuResponse* menuResponse, CreatureObject* player) {
-	if (menuResponse == nullptr || player == nullptr)
+void WaypointMenuComponent::fillObjectMenuResponse(SceneObject* sceneObject, ObjectMenuResponse* menuResponse, CreatureObject* player) const {
+	if (sceneObject == nullptr || !sceneObject->isWaypointObject() || player == nullptr) {
 		return;
+	}
 
-	Logger::console.info("WaypointObjectImplementation::fillObjectMenuResponse called!", true);
+	Logger::console.info("WaypointMenuComponent::fillObjectMenuResponse called!", true);
 
-	// Add default waypoint menu options
+	// Add waypoint menu options
 	menuResponse->addRadialMenuItem(20, 3, "@ui_radial:waypoint_activate"); // Activate
 	menuResponse->addRadialMenuItem(21, 3, "@ui_radial:waypoint_set_name"); // Set Name
 	menuResponse->addRadialMenuItem(22, 3, "@examine"); // Examine
-	menuResponse->addRadialMenuItem(83, 3, "Set Color"); // Set Color - NEW!
+	menuResponse->addRadialMenuItem(83, 3, "Set Color"); // Set Color
 	menuResponse->addRadialMenuItem(69, 3, "@ui_radial:item_destroy"); // Destroy
 
-	Logger::console.info("WaypointObjectImplementation: Added 5 menu items including Set Color", true);
+	Logger::console.info("WaypointMenuComponent: Added 5 menu items", true);
 }
 
-int WaypointObjectImplementation::handleObjectMenuSelect(CreatureObject* player, byte selectedID) {
-	if (player == nullptr)
+int WaypointMenuComponent::handleObjectMenuSelect(SceneObject* sceneObject, CreatureObject* player, byte selectedID) const {
+	if (!sceneObject->isWaypointObject() || player == nullptr) {
 		return 0;
+	}
+
+	ManagedReference<WaypointObject*> waypoint = cast<WaypointObject*>(sceneObject);
+
+	if (waypoint == nullptr) {
+		return 0;
+	}
 
 	ManagedReference<PlayerObject*> ghost = player->getPlayerObject();
 
-	if (ghost == nullptr)
+	if (ghost == nullptr) {
 		return 0;
-
-	ManagedReference<WaypointObject*> waypoint = _this.getReferenceUnsafeStaticCast();
+	}
 
 	switch (selectedID) {
 		case 20: // Activate
@@ -96,7 +61,7 @@ int WaypointObjectImplementation::handleObjectMenuSelect(CreatureObject* player,
 			// This is handled by the base object examine functionality
 			break;
 
-		case 83: // Set Color - NEW!
+		case 83: // Set Color
 			{
 				// Create SUI listbox for color selection
 				ManagedReference<SuiListBox*> suiBox = new SuiListBox(player, SuiWindowType::NONE);

--- a/MMOCoreORB/src/server/zone/objects/waypoint/components/WaypointMenuComponent.h
+++ b/MMOCoreORB/src/server/zone/objects/waypoint/components/WaypointMenuComponent.h
@@ -1,0 +1,36 @@
+/*
+ * WaypointMenuComponent.h
+ *
+ * Handles radial menu options for waypoint objects, including color selection
+ */
+
+#ifndef WAYPOINTMENUCOMPONENT_H_
+#define WAYPOINTMENUCOMPONENT_H_
+
+#include "server/zone/objects/scene/components/ObjectMenuComponent.h"
+
+class WaypointMenuComponent : public ObjectMenuComponent {
+public:
+	/**
+	 * Fills the radial options for waypoint objects
+	 * @pre { this object is locked }
+	 * @post { this object is locked, menuResponse is complete}
+	 * @param sceneObject the waypoint object
+	 * @param menuResponse ObjectMenuResponse that will be sent to the client
+	 * @param player the player using the object
+	 */
+	virtual void fillObjectMenuResponse(SceneObject* sceneObject, ObjectMenuResponse* menuResponse, CreatureObject* player) const;
+
+	/**
+	 * Handles the radial selection sent by the client
+	 * @pre { this object is locked, player is locked }
+	 * @post { this object is locked, player is locked }
+	 * @param sceneObject the waypoint object
+	 * @param player PlayerCreature that selected the option
+	 * @param selectedID selected menu id
+	 * @returns 0 if successful
+	 */
+	virtual int handleObjectMenuSelect(SceneObject* sceneObject, CreatureObject* player, byte selectedID) const;
+};
+
+#endif /* WAYPOINTMENUCOMPONENT_H_ */

--- a/bin/scripts/commands/waypointcolor.lua
+++ b/bin/scripts/commands/waypointcolor.lua
@@ -1,0 +1,49 @@
+--Copyright (C) 2010 <SWGEmu>
+
+--This File is part of Core3.
+
+--This program is free software; you can redistribute
+--it and/or modify it under the terms of the GNU Lesser
+--General Public License as published by the Free Software
+--Foundation; either version 2 of the License,
+--or (at your option) any later version.
+
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+--See the GNU Lesser General Public License for
+--more details.
+
+--You should have received a copy of the GNU Lesser General
+--Public License along with this program; if not, write to
+--the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+--Linking Engine3 statically or dynamically with other modules
+--is making a combined work based on Engine3.
+--Thus, the terms and conditions of the GNU Lesser General Public License
+--cover the whole combination.
+
+--In addition, as a special exception, the copyright holders of Engine3
+--give you permission to combine Engine3 program with free software
+--programs or libraries that are released under the GNU LGPL and with
+--code included in the standard release of Core3 under the GNU LGPL
+--license (or modified versions of such code, with unchanged license).
+--You may copy and distribute such a system following the terms of the
+--GNU LGPL for Engine3 and the licenses of the other code concerned,
+--provided that you include the source code of that other code when
+--and as the GNU LGPL requires distribution of source code.
+
+--Note that people who make modified versions of Engine3 are not obligated
+--to grant this special exception for their modified versions;
+--it is their choice whether to do so. The GNU Lesser General Public License
+--gives permission to release a modified version without this exception;
+--this exception also makes it possible to release a modified version
+
+
+WaypointcolorCommand = {
+	name = "waypointcolor",
+	addToCombatQueue = false,
+	called = false
+}
+
+AddCommand(WaypointcolorCommand)


### PR DESCRIPTION
- Introduced WaypointColorCommand to allow players to change waypoint colors via a SUI dialog.
- Implemented DatapadMenuComponent to include an option for managing waypoint colors.
- Enhanced WaypointObject and WaypointObjectImplementation to support color selection and updates.
- Created WaypointMenuComponent to handle radial menu options for waypoint objects, including color selection.
- Added necessary SUI callbacks for handling waypoint color selection.
- Updated ComponentManager to register new commands and components related to waypoint color management.