### PR TITLE
Enhance Knight Trials activation flow and eligibility checks

### DIFF
--- a/MMOCoreORB/bin/scripts/screenplays/jedi/components/ForceShrineMenuComponent.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/jedi/components/ForceShrineMenuComponent.lua
@@ -51,23 +51,35 @@ function ForceShrineMenuComponent:doMeditate(pObject, pPlayer)
 	else
 		-- Check if player has Padawan rank (rank_02) - if so, show Knight Trials
 		if (CreatureObject(pPlayer):hasSkill("force_title_jedi_rank_02")) then
-			local currentPoints = JediTrials:getKnightTrialPoints(pPlayer)
-			local currentTrial = JediTrials:getCurrentTrial(pPlayer)
-			local trialsCompleted = JediTrials:getTrialsCompleted(pPlayer)
-
-			-- Register the observer only if player is eligible (meets skill point requirements)
+			-- Check if player is eligible for Knight Trials (206+ skill points, 2+ trees)
 			if (JediTrials:isEligibleForKnightTrials(pPlayer)) then
-				printLuaError("ForceShrineMenuComponent:doMeditate - Registering observer for player: " .. SceneObject(pPlayer):getCustomObjectName())
-				-- First drop any existing observer to prevent duplicates
-				dropObserver(KILLEDCREATURE, "KnightTrials", "notifyKilledForPoints", pPlayer)
-				-- Now register the observer
-				createObserver(KILLEDCREATURE, "KnightTrials", "notifyKilledForPoints", pPlayer)
-			else
-				printLuaError("ForceShrineMenuComponent:doMeditate - NOT registering observer, player not eligible for Knight Trials yet")
-			end
+				-- Check if player has activated Knight Trials at shrine
+				-- We check for the "activatedAtShrine" flag specifically, not just "startedTrials"
+				-- This prevents confusion with the old auto-start system
+				local activatedAtShrine = tonumber(readScreenPlayData(pPlayer, "KnightTrials", "activatedAtShrine"))
 
-			-- Always show the progress box for Knight Trials
-			KnightTrials:showCurrentTrial(pPlayer)
+				if (activatedAtShrine ~= 1) then
+					-- Player hasn't activated at shrine yet - show activation dialog
+					KnightTrials:showKnightTrialsActivationDialog(pObject, pPlayer)
+				else
+					-- Player has activated - register observer and show progress
+					printLuaError("ForceShrineMenuComponent:doMeditate - Registering observer for player: " .. SceneObject(pPlayer):getCustomObjectName())
+					-- First drop any existing observer to prevent duplicates
+					dropObserver(KILLEDCREATURE, "KnightTrials", "notifyKilledForPoints", pPlayer)
+					-- Now register the observer
+					createObserver(KILLEDCREATURE, "KnightTrials", "notifyKilledForPoints", pPlayer)
+
+					-- Show the progress box for Knight Trials
+					KnightTrials:showCurrentTrial(pPlayer)
+				end
+			else
+				-- Not eligible yet - show eligibility requirements
+				local sui = SuiMessageBox.new("JediTrials", "emptyCallback")
+				sui.setTitle("Knight Trials")
+				sui.setPrompt("You are not yet eligible for the Knight Trials.\n\nYou must:\n- Be a Jedi Padawan (Rank 02)\n- Have at least 206 Jedi skill points invested\n- Have completed at least 2 full Force discipline trees\n\nContinue your training, young Padawan.")
+				sui.setOkButtonText("Close")
+				sui.sendTo(pPlayer)
+			end
 		else
 			CreatureObject(pPlayer):sendSystemMessage("@jedi_trials:force_shrine_wisdom_" .. getRandomNumber(1, 15))
 		end

--- a/MMOCoreORB/bin/scripts/screenplays/jedi/jedi_trials.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/jedi/jedi_trials.lua
@@ -484,6 +484,7 @@ function JediTrials:resetTrialData(pPlayer, trialType)
 	elseif (trialType == "knight") then
 		deleteScreenPlayData(pPlayer, "KnightTrials", "trialsCompleted")
 		deleteScreenPlayData(pPlayer, "KnightTrials", "startedTrials")
+		deleteScreenPlayData(pPlayer, "KnightTrials", "activatedAtShrine")
 		deleteScreenPlayData(pPlayer, "JediTrials", "JediCouncil")
 	end
 
@@ -523,6 +524,7 @@ end
 
 function JediTrials:completeKnightForTesting(pPlayer, councilType)
 	writeScreenPlayData(pPlayer, "KnightTrials", "startedTrials", 1)
+	writeScreenPlayData(pPlayer, "KnightTrials", "activatedAtShrine", 1)
 	writeScreenPlayData(pPlayer, "JediTrials", "JediCouncil", councilType)
 	self:setTrialsCompleted(pPlayer, #knightTrialQuests)
 	self:unlockJediKnight(pPlayer)

--- a/MMOCoreORB/bin/scripts/screenplays/jedi/knight/knight_trials.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/jedi/knight/knight_trials.lua
@@ -21,6 +21,53 @@ local function playerParticipatedInKill(pPlayer, pCreature)
 	return isInRange
 end
 
+function KnightTrials:showKnightTrialsActivationDialog(pObject, pPlayer)
+	if (pPlayer == nil) then
+		return
+	end
+
+	-- Show activation dialog
+	local sui = SuiMessageBox.new("KnightTrials", "knightTrialsActivationCallback")
+
+	if (pObject ~= nil) then
+		sui.setTargetNetworkId(SceneObject(pObject):getObjectID())
+	end
+
+	sui.setTitle("Knight Trials")
+	sui.setPrompt("Greetings, Padawan.\n\nYou have grown strong in the Force, mastering multiple disciplines and honing your skills. The path to Knighthood now beckons.\n\nThe Knight Trials await you. By hunting creatures across the galaxy and proving your strength in combat, you will earn the respect of the Jedi Council.\n\nYou must earn 50,000 PvE points through battle. Stronger foes grant more points.\n\nWould you like to begin the Knight Trials?")
+
+	sui.setOkButtonText("Begin Knight Trials")
+	sui.setCancelButtonText("Not Yet")
+
+	sui.sendTo(pPlayer)
+end
+
+function KnightTrials:knightTrialsActivationCallback(pPlayer, pSui, eventIndex, ...)
+	if (pPlayer == nil) then
+		return
+	end
+
+	-- eventIndex == 1 means Cancel button was pressed
+	if (eventIndex == 1) then
+		CreatureObject(pPlayer):sendSystemMessage("You have chosen to delay your Knight Trials. Return to any Force Shrine when you are ready.")
+		return
+	end
+
+	-- Player chose to begin - verify eligibility one more time
+	if (not JediTrials:isEligibleForKnightTrials(pPlayer)) then
+		CreatureObject(pPlayer):sendSystemMessage("You are no longer eligible for Knight Trials.")
+		return
+	end
+
+	-- Activate the Knight Trials
+	KnightTrials:startKnightTrials(pPlayer)
+
+	-- Set the shrine activation flag (separate from startedTrials)
+	writeScreenPlayData(pPlayer, "KnightTrials", "activatedAtShrine", 1)
+
+	CreatureObject(pPlayer):sendSystemMessage("Knight Trials activated! You will now earn PvE points for hunting creatures. Check your progress at any Force Shrine.")
+end
+
 function KnightTrials:startKnightTrials(pPlayer)
 	local randomShrinePlanet = JediTrials:getRandomDifferentShrinePlanet(pPlayer)
 	local pRandShrine = JediTrials:getRandomShrineOnPlanet(randomShrinePlanet)
@@ -302,6 +349,21 @@ function KnightTrials:showCurrentTrial(pPlayer)
 
 	local trialData = knightTrialQuests[trialNumber]
 
+	-- If trialNumber is 0 or trialData is nil, just show PvE points progress
+	-- This happens when Knight Trials are first activated (currentTrial = 0)
+	if (trialNumber == 0 or trialData == nil) then
+		local currentPoints = JediTrials:getKnightTrialPoints(pPlayer)
+		local pointProgress = string.format("Knight Trials - PvE Progression\n\nYour Progress: %d / %d points\n\nHunt creatures across the galaxy to earn points. Stronger foes grant more points.\n\nAt 25,000 points, you will choose your Jedi Council (Light or Dark).\n\nAt 50,000 points, you will become a Jedi Knight!", currentPoints, KNIGHT_TRIALS_REQUIRED_POINTS)
+
+		local sui = SuiMessageBox.new("KnightTrials", "noCallback")
+		sui.setTitle("@jedi_trials:knight_trials_title")
+		sui.setPrompt(pointProgress)
+		sui.setOkButtonText("@jedi_trials:button_close")
+		sui.hideCancelButton()
+		sui.sendTo(pPlayer)
+		return
+	end
+
 	-- Only skip if it's not the council choice trial
 	-- Council choice trial (TRIAL_COUNCIL) should always show the council dialog when first encountered
 	if (trialData.trialType ~= TRIAL_COUNCIL and trialsCompleted == trialNumber) then
@@ -432,9 +494,11 @@ function KnightTrials:onPlayerLoggedIn(pPlayer)
 		printLuaError("KnightTrials:onPlayerLoggedIn - NOT registering observer. Has rank_02: " .. tostring(CreatureObject(pPlayer):hasSkill("force_title_jedi_rank_02")) .. ", Has rank_03: " .. tostring(CreatureObject(pPlayer):hasSkill("force_title_jedi_rank_03")) .. ", Eligible: " .. tostring(JediTrials:isEligibleForKnightTrials(pPlayer)))
 	end
 
-	if (JediTrials:isEligibleForKnightTrials(pPlayer) and not JediTrials:isOnKnightTrials(pPlayer)) then
-		KnightTrials:startKnightTrials(pPlayer)
-	elseif (JediTrials:isOnKnightTrials(pPlayer)) then
+	-- Don't auto-start Knight Trials on login - player must activate at shrine
+	-- if (JediTrials:isEligibleForKnightTrials(pPlayer) and not JediTrials:isOnKnightTrials(pPlayer)) then
+	-- 	KnightTrials:startKnightTrials(pPlayer)
+	-- elseif (JediTrials:isOnKnightTrials(pPlayer)) then
+	if (JediTrials:isOnKnightTrials(pPlayer)) then
 		local trialNumber = JediTrials:getCurrentTrial(pPlayer)
 
 		if (trialNumber <= 0) then
@@ -514,6 +578,13 @@ function KnightTrials:notifyKilledForPoints(pPlayer, pVictim)
 	-- Check if player meets Knight Trial eligibility requirements (206+ Jedi skill points)
 	if (not JediTrials:isEligibleForKnightTrials(pPlayer)) then
 		printLuaError("KnightTrials:notifyKilledForPoints - player not eligible for Knight Trials (insufficient Jedi skill points)")
+		return 0
+	end
+
+	-- Check if player has activated Knight Trials at a Force Shrine
+	local activatedAtShrine = tonumber(readScreenPlayData(pPlayer, "KnightTrials", "activatedAtShrine"))
+	if (activatedAtShrine ~= 1) then
+		printLuaError("KnightTrials:notifyKilledForPoints - player has not activated Knight Trials at a shrine")
 		return 0
 	end
 

--- a/MMOCoreORB/src/server/zone/objects/tangible/terminal/components/StructureTerminalMenuComponent.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/terminal/components/StructureTerminalMenuComponent.cpp
@@ -101,8 +101,8 @@ void StructureTerminalMenuComponent::fillObjectMenuResponse(SceneObject* sceneOb
 			}
 		}
 
-		// Allow users on vendor list to create vendors
-		if (structureObject->isOnPermissionList("VENDOR", creature)) {
+		// Allow users on vendor list to create vendors (but not if they're already admin - admins already have this option)
+		if (structureObject->isOnPermissionList("VENDOR", creature) && !structureObject->isOnAdminList(creature)) {
 			if (creature->hasSkill("crafting_artisan_business_03")) {
 				menuResponse->addRadialMenuItem(RADIAL_ROOT_MANAGEMENT, 3, "@player_structure:management"); // Structure Management
 				menuResponse->addRadialMenuItemToRadialID(RADIAL_ROOT_MANAGEMENT, 130, 3, "@player_structure:create_vendor"); // Create Vendor
@@ -273,8 +273,8 @@ int StructureTerminalMenuComponent::handleObjectMenuSelect(SceneObject* sceneObj
 			}
 		}
 
-		// Handle vendor list users for civic structures
-		if (structureObject->isOnPermissionList("VENDOR", creature)) {
+		// Handle vendor list users for civic structures (but not if they're already admin - admins already handled above)
+		if (structureObject->isOnPermissionList("VENDOR", creature) && !structureObject->isOnAdminList(creature)) {
 			if (selectedID == 130) { // Create Vendor
 				creature->executeObjectControllerAction(STRING_HASHCODE("createvendor"));
 			}


### PR DESCRIPTION
- Added activation dialog for Knight Trials at Force Shrines.
- Implemented checks for player eligibility and activation status.
- Updated data management for Knight Trials to ensure proper state handling.
- Improved user feedback for eligibility requirements.
- Refined vendor creation permissions in Structure Terminal.