### PR TITLE
Ender foundling start weapon names updates and Fixed Gate for Schematics and fixed Messaging on Mandalorian NPC's

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_foundling_informant_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_foundling_informant_conv.lua
@@ -116,6 +116,19 @@ turnin_final = ConvoScreen:new {
 mandoFoundlingInformantConvoTemplate:addScreen(turnin_final)
 
 -- --------------------------------------------------------
+-- GO AWAY: player has not started the Mandalorian arc.
+-- Send them to the recruiter in the Mos Eisley cantina on Tatooine.
+-- --------------------------------------------------------
+go_away = ConvoScreen:new {
+	id = "go_away",
+	leftDialog = "",
+	customDialogText = "I don't know you, and I've no work for a stranger. If you mean to walk the Way, find the Mandalorian Recruiter in the Mos Eisley cantina on Tatooine. Earn it from them first. Now move along.",
+	stopConversation = "true",
+	options = {}
+}
+mandoFoundlingInformantConvoTemplate:addScreen(go_away)
+
+-- --------------------------------------------------------
 -- BYE
 -- --------------------------------------------------------
 bye = ConvoScreen:new {

--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_spynet_operative_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_spynet_operative_conv.lua
@@ -26,6 +26,19 @@ intro = ConvoScreen:new {
 mandoSpynetOperativeConvoTemplate:addScreen(intro)
 
 -- --------------------------------------------------------
+-- GO AWAY: player has not started the Mandalorian arc.
+-- Send them to the recruiter in the Mos Eisley cantina on Tatooine.
+-- --------------------------------------------------------
+go_away = ConvoScreen:new {
+	id = "go_away",
+	leftDialog = "",
+	customDialogText = "Spynet has no file on you, and I don't deal with outsiders. If you want this work, go to the Mandalorian Recruiter in the Mos Eisley cantina on Tatooine and earn your way in. Until then, you were never here.",
+	stopConversation = "true",
+	options = {}
+}
+mandoSpynetOperativeConvoTemplate:addScreen(go_away)
+
+-- --------------------------------------------------------
 -- HELMET NOT EQUIPPED
 -- --------------------------------------------------------
 no_helmet = ConvoScreen:new {

--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
@@ -21,7 +21,6 @@ intro = ConvoScreen:new {
 	options = {
 		{"Tell me about the Mandalorian way.", "explain"},
 		{"I am ready to prove myself.", "check_prereqs"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Nothing.", "bye"},
 	}
 }
@@ -37,7 +36,6 @@ explain = ConvoScreen:new {
 	stopConversation = "false",
 	options = {
 		{"I am ready to prove myself.", "check_prereqs"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"I understand.", "bye"},
 	}
 }
@@ -67,7 +65,6 @@ arc_in_progress = ConvoScreen:new {
 	options = {
 		{"What is my status?", "foundling_status"},
 		{"My contact or waypoint is broken. Reset them.", "foundling_resync"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Understood.", "bye"},
 	}
 }
@@ -155,7 +152,6 @@ chapter_gate_ready = ConvoScreen:new {
 	stopConversation = "false",
 	options = {
 		{"What is my Mandalorian Way status?", "mando_way_status"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Understood.", "bye"},
 	}
 }
@@ -172,7 +168,6 @@ clanbound = ConvoScreen:new {
 	options = {
 		{"What's next?", "clanbound_whats_next"},
 		{"What is my Mandalorian Way status?", "mando_way_status"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Understood.", "bye"},
 	}
 }
@@ -209,10 +204,25 @@ mando_armory_shop = ConvoScreen:new {
 		{"Mandalorian Geo blaster schematic (125000 credits).", "buy_mando_armory_1"},
 		{"Mandalorian slugthrower schematic (125000 credits).", "buy_mando_armory_2"},
 		{"Mandalorian lightning cannon schematic (125000 credits).", "buy_mando_armory_3"},
-		{"Back.", "intro"},
+		{"Back.", "tribesman_hub"},
 	}
 }
 mandoTrialmasterConvoTemplate:addScreen(mando_armory_shop)
+
+-- Tribesman hub: landing screen for a finished Mandalorian Tribesman (e.g. "Back" out of the armory).
+-- Only reachable from the armory shop, which itself is gated to chapter5Complete, so the armory option here never leaks.
+tribesman_hub = ConvoScreen:new {
+	id = "tribesman_hub",
+	leftDialog = "",
+	customDialogText = "Anything else, Tribesman? You have walked the whole Way.",
+	stopConversation = "false",
+	options = {
+		{"What is my Mandalorian Way status?", "mando_way_status"},
+		{"Armory schematics.", "mando_armory_shop"},
+		{"Nothing.", "bye"},
+	}
+}
+mandoTrialmasterConvoTemplate:addScreen(tribesman_hub)
 
 buy_mando_armory_1 = ConvoScreen:new {
 	id = "buy_mando_armory_1",

--- a/MMOCoreORB/bin/scripts/object/weapon/ranged/carbine/carbine_foundling_cdef_beskar.lua
+++ b/MMOCoreORB/bin/scripts/object/weapon/ranged/carbine/carbine_foundling_cdef_beskar.lua
@@ -2,7 +2,7 @@
 -- Bellum: Foundling kit. CDEF certification, Beskar naming, recruiter grant on arc start.
 
 object_weapon_ranged_carbine_carbine_foundling_cdef_beskar = object_weapon_ranged_carbine_shared_carbine_cdef:new {
-	customObjectName = "Foundling Beskar Polished Carbine",
+	customName = "Foundling Beskar Polished Carbine",
 
 	playerRaces = {
 		"object/creature/player/bothan_male.iff",

--- a/MMOCoreORB/bin/scripts/object/weapon/ranged/pistol/pistol_foundling_cdef_beskar.lua
+++ b/MMOCoreORB/bin/scripts/object/weapon/ranged/pistol/pistol_foundling_cdef_beskar.lua
@@ -2,7 +2,7 @@
 -- Bellum: Foundling kit. CDEF certification, Beskar naming, recruiter grant on arc start.
 
 object_weapon_ranged_pistol_pistol_foundling_cdef_beskar = object_weapon_ranged_pistol_shared_pistol_cdef:new {
-	customObjectName = "Foundling Beskar Polished Pistol",
+	customName = "Foundling Beskar Polished Pistol",
 
 	playerRaces = {
 		"object/creature/player/bothan_male.iff",

--- a/MMOCoreORB/bin/scripts/object/weapon/ranged/rifle/rifle_foundling_cdef_beskar.lua
+++ b/MMOCoreORB/bin/scripts/object/weapon/ranged/rifle/rifle_foundling_cdef_beskar.lua
@@ -2,7 +2,7 @@
 -- Bellum: Foundling kit. CDEF certification, Beskar naming, recruiter grant on arc start.
 
 object_weapon_ranged_rifle_rifle_foundling_cdef_beskar = object_weapon_ranged_rifle_shared_rifle_cdef:new {
-	customObjectName = "Foundling Beskar Polished Rifle",
+	customName = "Foundling Beskar Polished Rifle",
 
 	playerRaces = {
 		"object/creature/player/bothan_male.iff",

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_foundling_informant_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_foundling_informant_conv_handler.lua
@@ -28,6 +28,11 @@ function MandoFoundlingInformantConvoHandler:getInitialScreen(pPlayer, pNpc, pCo
 	))
 
 	if (not inArc) then
+		-- Player who never started the Mandalorian arc: brush them off toward the recruiter.
+		-- (Players who already finished the arc are simply past this contact — stay silent.)
+		if (ch0 ~= 1 and arcComplete ~= 1) then
+			return convoTemplate:getScreen("go_away")
+		end
 		return nil
 	end
 

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_spynet_operative_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_spynet_operative_conv_handler.lua
@@ -8,6 +8,11 @@ function MandoSpynetOperativeConvoHandler:getInitialScreen(pPlayer, pNpc, pConvT
 
 	local convoTemplate = LuaConversationTemplate(pConvTemplate)
 
+	-- Player who never started the Mandalorian arc: send them to the recruiter, not here.
+	if (MandoWayOfLife:readInt(pPlayer, "chapter0Started") ~= 1 and not MandoWayOfLife:isArcComplete(pPlayer)) then
+		return convoTemplate:getScreen("go_away")
+	end
+
 	-- Helmet check first
 	if (not MandoWayOfLife:hasFoundlingHelmet(pPlayer)) then
 		return convoTemplate:getScreen("no_helmet")

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
@@ -42,6 +42,8 @@ function MandoTrialmasterConvoHandler:getInitialScreen(pPlayer, pNpc, pConvTempl
 		LuaConversationScreen(pCloned):setCustomDialogText(
 			"You are a Mandalorian Tribesman. There is nothing left here to prove. Well fought."
 		)
+		-- Armory schematics open only to a finished Tribesman (final phase of the Way).
+		LuaConversationScreen(pCloned):addOption("Armory schematics.", "mando_armory_shop")
 		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, pCloned)
 	end
 

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
@@ -2815,6 +2815,8 @@ function MandoWayOfLife:playerEligibleForMandoArmoryCatalog(pPlayer)
 	if (pPlayer == nil) then return false end
 	if (not self:isArcComplete(pPlayer)) then return false end
 	if (not CreatureObject(pPlayer):hasSkill("combat_bountyhunter_novice")) then return false end
+	-- Armory schematics unlock only after the entire Way is finished (Mandalorian Tribesman / final phase).
+	if (self:readInt(pPlayer, "chapter5Complete") ~= 1) then return false end
 	return true
 end
 
@@ -2825,15 +2827,11 @@ function MandoWayOfLife:trySellMandoArmorySchematic(pPlayer, tier)
 	if (tier == nil or type(tier) ~= "number" or tier < 1 or tier > 3) then return false, "Invalid request." end
 
 	if (not self:playerEligibleForMandoArmoryCatalog(pPlayer)) then
-		return false, "You are not cleared for the Mandalorian armory. Finish the Foundling arc and earn Novice Bounty Hunter first."
+		return false, "You are not cleared for the Mandalorian armory. Walk the entire Way and earn the Mandalorian Tribesman rank first. Then the clan armory opens to you."
 	end
 
 	local sale = self.mandoWayArmorySchematicSales[tier]
 	if (sale == nil) then return false, "Invalid request." end
-
-	if (self:readInt(pPlayer, sale.chapterFlag) ~= 1) then
-		return false, "You have not completed the trial for that rank yet. Earn the chapter first, then come back for the schematic."
-	end
 
 	local pInventory = SceneObject(pPlayer):getSlottedObject("inventory")
 	if (pInventory == nil) then return false, "I cannot reach your inventory." end


### PR DESCRIPTION
 5d29c1cdec  Fix Foundling CDEF starter weapon names      ← topic 2
  e5c618e41d  Fix Gate Mando armory schematics + brush-offs     ← topic 1

Title: Mando Way: gate armory schematics to Tribesman + fix Foundling CDEF weapon names

  Summary

  Two Mandalorian Way fixes:

  1. Armory schematics gated to full questline completion. Previously the recruiter's armory schematics could be
  bought partway through the questline (per-chapter unlock). Now they require finishing the entire Way
  (Mandalorian Tribesman / chapter 5). The shop option is also hidden until then.
  2. Foundling CDEF starter weapon names now actually display. They used customObjectName, a field weapons don't
  read, so the custom names were silently ignored. Switched to customName.

  Changes

  Schematics gate / questline gating
  - Purchase now requires chapter5Complete; removed the per-tier chapter gate so finishing the Way unlocks all
  three schematics at once.
  - Recruiter "Armory schematics" option is hidden until Tribesman, then injected dynamically; added a Tribesman
  hub screen so the shop's "Back" lands somewhere sensible.
  - Foundling informant and Spynet operative now brush off players who haven't started the questline, pointing
  them to the recruiter in the Mos Eisley cantina.

  Weapon naming
  - Foundling CDEF pistol/carbine/rifle: customObjectName → customName.

  Behavior / deploy notes
  - Lua-only changes — take effect on script reload/restart (no recompile).
  - Weapon name fix applies to newly granted/crafted weapons only; existing inventory copies keep their old name.
  - Full client-side naming (examine text, all instances) still needs the bg_custom1.tre work — tracked in a local
  spec doc, out of scope for this PR.

  Testing
  - Verified gating logic: schematic purchase blocked until chapter5Complete; option hidden pre-Tribesman.
  - Informant/operative brush-off paths route unstarted players to the recruiter.
  - No automated tests for Lua screenplays; behavior reviewed by reading the gate/handler flow.