### PR TITLE
Ender mando patch

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_foundling_informant_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_foundling_informant_conv.lua
@@ -116,6 +116,19 @@ turnin_final = ConvoScreen:new {
 mandoFoundlingInformantConvoTemplate:addScreen(turnin_final)
 
 -- --------------------------------------------------------
+-- GO AWAY: player has not started the Mandalorian arc.
+-- Send them to the recruiter in the Mos Eisley cantina on Tatooine.
+-- --------------------------------------------------------
+go_away = ConvoScreen:new {
+	id = "go_away",
+	leftDialog = "",
+	customDialogText = "I don't know you, and I've no work for a stranger. If you mean to walk the Way, find the Mandalorian Recruiter in the Mos Eisley cantina on Tatooine. Earn it from them first. Now move along.",
+	stopConversation = "true",
+	options = {}
+}
+mandoFoundlingInformantConvoTemplate:addScreen(go_away)
+
+-- --------------------------------------------------------
 -- BYE
 -- --------------------------------------------------------
 bye = ConvoScreen:new {

--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_spynet_operative_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_spynet_operative_conv.lua
@@ -26,6 +26,19 @@ intro = ConvoScreen:new {
 mandoSpynetOperativeConvoTemplate:addScreen(intro)
 
 -- --------------------------------------------------------
+-- GO AWAY: player has not started the Mandalorian arc.
+-- Send them to the recruiter in the Mos Eisley cantina on Tatooine.
+-- --------------------------------------------------------
+go_away = ConvoScreen:new {
+	id = "go_away",
+	leftDialog = "",
+	customDialogText = "Spynet has no file on you, and I don't deal with outsiders. If you want this work, go to the Mandalorian Recruiter in the Mos Eisley cantina on Tatooine and earn your way in. Until then, you were never here.",
+	stopConversation = "true",
+	options = {}
+}
+mandoSpynetOperativeConvoTemplate:addScreen(go_away)
+
+-- --------------------------------------------------------
 -- HELMET NOT EQUIPPED
 -- --------------------------------------------------------
 no_helmet = ConvoScreen:new {

--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
@@ -21,7 +21,6 @@ intro = ConvoScreen:new {
 	options = {
 		{"Tell me about the Mandalorian way.", "explain"},
 		{"I am ready to prove myself.", "check_prereqs"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Nothing.", "bye"},
 	}
 }
@@ -37,7 +36,6 @@ explain = ConvoScreen:new {
 	stopConversation = "false",
 	options = {
 		{"I am ready to prove myself.", "check_prereqs"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"I understand.", "bye"},
 	}
 }
@@ -67,7 +65,6 @@ arc_in_progress = ConvoScreen:new {
 	options = {
 		{"What is my status?", "foundling_status"},
 		{"My contact or waypoint is broken. Reset them.", "foundling_resync"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Understood.", "bye"},
 	}
 }
@@ -155,7 +152,6 @@ chapter_gate_ready = ConvoScreen:new {
 	stopConversation = "false",
 	options = {
 		{"What is my Mandalorian Way status?", "mando_way_status"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Understood.", "bye"},
 	}
 }
@@ -172,7 +168,6 @@ clanbound = ConvoScreen:new {
 	options = {
 		{"What's next?", "clanbound_whats_next"},
 		{"What is my Mandalorian Way status?", "mando_way_status"},
-		{"Armory schematics (rank gated).", "mando_armory_shop"},
 		{"Understood.", "bye"},
 	}
 }
@@ -209,10 +204,25 @@ mando_armory_shop = ConvoScreen:new {
 		{"Mandalorian Geo blaster schematic (125000 credits).", "buy_mando_armory_1"},
 		{"Mandalorian slugthrower schematic (125000 credits).", "buy_mando_armory_2"},
 		{"Mandalorian lightning cannon schematic (125000 credits).", "buy_mando_armory_3"},
-		{"Back.", "intro"},
+		{"Back.", "tribesman_hub"},
 	}
 }
 mandoTrialmasterConvoTemplate:addScreen(mando_armory_shop)
+
+-- Tribesman hub: landing screen for a finished Mandalorian Tribesman (e.g. "Back" out of the armory).
+-- Only reachable from the armory shop, which itself is gated to chapter5Complete, so the armory option here never leaks.
+tribesman_hub = ConvoScreen:new {
+	id = "tribesman_hub",
+	leftDialog = "",
+	customDialogText = "Anything else, Tribesman? You have walked the whole Way.",
+	stopConversation = "false",
+	options = {
+		{"What is my Mandalorian Way status?", "mando_way_status"},
+		{"Armory schematics.", "mando_armory_shop"},
+		{"Nothing.", "bye"},
+	}
+}
+mandoTrialmasterConvoTemplate:addScreen(tribesman_hub)
 
 buy_mando_armory_1 = ConvoScreen:new {
 	id = "buy_mando_armory_1",

--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
@@ -273,4 +273,26 @@ mando_armor_retro_grant = ConvoScreen:new {
 }
 mandoTrialmasterConvoTemplate:addScreen(mando_armor_retro_grant)
 
+-- Recruiter-only (handler): one-time per login account restoration of equippable rank titles.
+mando_title_retro = ConvoScreen:new {
+	id = "mando_title_retro",
+	leftDialog = "",
+	customDialogText = "For veterans of the Way: if you earned rank badges but your Mandalorian titles never appeared in Community, I can restore every equippable title you have earned on this character — Foundling through your current rank — once per login account. Another character on your account cannot claim this again.",
+	stopConversation = "false",
+	options = {
+		{"Restore my rank titles.", "mando_title_retro_grant"},
+		{"Not now.", "bye"},
+	}
+}
+mandoTrialmasterConvoTemplate:addScreen(mando_title_retro)
+
+mando_title_retro_grant = ConvoScreen:new {
+	id = "mando_title_retro_grant",
+	leftDialog = "",
+	customDialogText = "Processing.",
+	stopConversation = "true",
+	options = {}
+}
+mandoTrialmasterConvoTemplate:addScreen(mando_title_retro_grant)
+
 addConversationTemplate("mandoTrialmasterConvoTemplate", mandoTrialmasterConvoTemplate)

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_foundling_informant_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_foundling_informant_conv_handler.lua
@@ -28,6 +28,11 @@ function MandoFoundlingInformantConvoHandler:getInitialScreen(pPlayer, pNpc, pCo
 	))
 
 	if (not inArc) then
+		-- Player who never started the Mandalorian arc: brush them off toward the recruiter.
+		-- (Players who already finished the arc are simply past this contact — stay silent.)
+		if (ch0 ~= 1 and arcComplete ~= 1) then
+			return convoTemplate:getScreen("go_away")
+		end
 		return nil
 	end
 

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_spynet_operative_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_spynet_operative_conv_handler.lua
@@ -8,6 +8,11 @@ function MandoSpynetOperativeConvoHandler:getInitialScreen(pPlayer, pNpc, pConvT
 
 	local convoTemplate = LuaConversationTemplate(pConvTemplate)
 
+	-- Player who never started the Mandalorian arc: send them to the recruiter, not here.
+	if (MandoWayOfLife:readInt(pPlayer, "chapter0Started") ~= 1 and not MandoWayOfLife:isArcComplete(pPlayer)) then
+		return convoTemplate:getScreen("go_away")
+	end
+
 	-- Helmet check first
 	if (not MandoWayOfLife:hasFoundlingHelmet(pPlayer)) then
 		return convoTemplate:getScreen("no_helmet")

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
@@ -42,6 +42,8 @@ function MandoTrialmasterConvoHandler:getInitialScreen(pPlayer, pNpc, pConvTempl
 		LuaConversationScreen(pCloned):setCustomDialogText(
 			"You are a Mandalorian Tribesman. There is nothing left here to prove. Well fought."
 		)
+		-- Armory schematics open only to a finished Tribesman (final phase of the Way).
+		LuaConversationScreen(pCloned):addOption("Armory schematics.", "mando_armory_shop")
 		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, pCloned)
 	end
 

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
@@ -3,16 +3,34 @@
 
 MandoTrialmasterConvoHandler = conv_handler:new {}
 
-function MandoTrialmasterConvoHandler:withRecruiterArmorRetroOption(pPlayer, pNpc, pScreen)
+function MandoTrialmasterConvoHandler:withRecruiterRetroOptions(pPlayer, pNpc, pScreen)
 	if (pScreen == nil or pPlayer == nil or pNpc == nil) then return pScreen end
 	if (not MandoWayOfLife:isMandoRecruiterNpc(pNpc)) then return pScreen end
-	if (MandoWayOfLife:hasAccountArmorRetroClaimed(pPlayer)) then return pScreen end
 
 	local pCloned = LuaConversationScreen(pScreen):cloneScreen()
-	LuaConversationScreen(pCloned):addOption(
-		"Reissue all Way armor sets (once per account).",
-		"mando_armor_retro"
-	)
+	local cloned = LuaConversationScreen(pCloned)
+	local added = false
+
+	if (not MandoWayOfLife:hasAccountArmorRetroClaimed(pPlayer)) then
+		cloned:addOption(
+			"Reissue all Way armor sets (once per account).",
+			"mando_armor_retro"
+		)
+		added = true
+	end
+
+	if (not MandoWayOfLife:hasAccountTitleRetroClaimed(pPlayer)) then
+		local maxChapter = MandoWayOfLife:getHighestEarnedChapter(pPlayer)
+		if (maxChapter >= 0 and MandoWayOfLife:countMissingChapterTitleSkills(pPlayer, maxChapter) > 0) then
+			cloned:addOption(
+				"Restore my Way rank titles (once per account).",
+				"mando_title_retro"
+			)
+			added = true
+		end
+	end
+
+	if (not added) then return pScreen end
 	return pCloned
 end
 
@@ -44,7 +62,7 @@ function MandoTrialmasterConvoHandler:getInitialScreen(pPlayer, pNpc, pConvTempl
 		)
 		-- Armory schematics open only to a finished Tribesman (final phase of the Way).
 		LuaConversationScreen(pCloned):addOption("Armory schematics.", "mando_armory_shop")
-		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, pCloned)
+		return self:withRecruiterRetroOptions(pPlayer, pNpc, pCloned)
 	end
 
 	-- Chapter 4 complete — Clanbound. Check Jabba gate for Mandalorian Tribesman title.
@@ -58,37 +76,37 @@ function MandoTrialmasterConvoHandler:getInitialScreen(pPlayer, pNpc, pConvTempl
 			LuaConversationScreen(pCloned):setCustomDialogText(
 				"Word of your deeds reached me before you did. The Hunts have spoken. You are a Mandalorian Tribesman. Wear the title."
 			)
-			return self:withRecruiterArmorRetroOption(pPlayer, pNpc, pCloned)
+			return self:withRecruiterRetroOptions(pPlayer, pNpc, pCloned)
 		end
 		-- No Jabba badge yet: send them to earn it
 		local pCloned = LuaConversationScreen(pBase):cloneScreen()
 		LuaConversationScreen(pCloned):setCustomDialogText(
 			"You are Clanbound. The last trial runs through the Hutts on Tatooine. When you want the full brief, ask me what comes next."
 		)
-		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, pCloned)
+		return self:withRecruiterRetroOptions(pPlayer, pNpc, pCloned)
 	end
 
 	-- Arc complete + Novice BH: ready for chapter gate cycle
 	if (MandoWayOfLife:isArcComplete(pPlayer)) then
 		if (not CreatureObject(pPlayer):hasSkill("combat_bountyhunter_novice")) then
-			return self:withRecruiterArmorRetroOption(pPlayer, pNpc, convoTemplate:getScreen("arc_complete_no_bh"))
+			return self:withRecruiterRetroOptions(pPlayer, pNpc, convoTemplate:getScreen("arc_complete_no_bh"))
 		end
-		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, convoTemplate:getScreen("chapter_gate_ready"))
+		return self:withRecruiterRetroOptions(pPlayer, pNpc, convoTemplate:getScreen("chapter_gate_ready"))
 	end
 
 	-- Arc started but not complete: player is mid-arc
 	if (MandoWayOfLife:readInt(pPlayer, "chapter0Started") == 1) then
 		MandoWayOfLife:ensureFoundlingInformant(pPlayer)
-		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, convoTemplate:getScreen("arc_in_progress"))
+		return self:withRecruiterRetroOptions(pPlayer, pNpc, convoTemplate:getScreen("arc_in_progress"))
 	end
 
 	-- Prerequisites not met
 	if (not MandoWayOfLife:meetsPrerequisites(pPlayer)) then
-		return self:withRecruiterArmorRetroOption(pPlayer, pNpc, convoTemplate:getScreen("prereqs_missing"))
+		return self:withRecruiterRetroOptions(pPlayer, pNpc, convoTemplate:getScreen("prereqs_missing"))
 	end
 
 	-- Ready to start arc
-	return self:withRecruiterArmorRetroOption(pPlayer, pNpc, self:getArcAcceptScreen(pPlayer, convoTemplate))
+	return self:withRecruiterRetroOptions(pPlayer, pNpc, self:getArcAcceptScreen(pPlayer, convoTemplate))
 end
 
 function MandoTrialmasterConvoHandler:runScreenHandlers(pConvTemplate, pPlayer, pNpc, selectedOption, pConvScreen)
@@ -129,6 +147,24 @@ function MandoTrialmasterConvoHandler:runScreenHandlers(pConvTemplate, pPlayer, 
 		cloned:setCustomDialogText(msg)
 		cloned:setStopConversation(true)
 		MandoWayOfLife:logDiagPlayer(pPlayer, string.format("Recruiter convo: mando_armor_retro_grant ok=%s.", tostring(ok)))
+		return pCloned
+
+	elseif (screenID == "mando_title_retro_grant") then
+		if (not MandoWayOfLife:isMandoRecruiterNpc(pNpc)) then
+			local luaScreen = LuaConversationScreen(pConvScreen)
+			local pCloned = luaScreen:cloneScreen()
+			local cloned = LuaConversationScreen(pCloned)
+			cloned:setCustomDialogText("That restoration is handled by the Mandalorian Recruiter in the Mos Eisley cantina.")
+			cloned:setStopConversation(true)
+			return pCloned
+		end
+		local ok, msg = MandoWayOfLife:tryGrantAccountTitleRetro(pPlayer)
+		local luaScreen = LuaConversationScreen(pConvScreen)
+		local pCloned = luaScreen:cloneScreen()
+		local cloned = LuaConversationScreen(pCloned)
+		cloned:setCustomDialogText(msg)
+		cloned:setStopConversation(true)
+		MandoWayOfLife:logDiagPlayer(pPlayer, string.format("Recruiter convo: mando_title_retro_grant ok=%s.", tostring(ok)))
 		return pCloned
 
 	elseif (screenID == "buy_mando_armory_1" or screenID == "buy_mando_armory_2" or screenID == "buy_mando_armory_3") then

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
@@ -42,12 +42,13 @@ MandoWayOfLife = ScreenPlay:new {
 		cellId   = 1082877,
 		template = "mando_trialmaster",
 		name     = "Mando Recruiter",
-		-- World waypoint (exterior) - cantina block; NPC is inside cell 1082877
+		-- Datapad pin: grantRecruiterWaypoint() prefers live recruiter world position (cell 1082877).
+		-- Static fallback = Mos Eisley cantina block exterior (matches city mobiles ~3526, -4799).
 		recruiterWaypointName = "Mandalorian Recruiter",
-		recruiterWaypointDesc = "Mos Eisley cantina. Speak with the Mandalorian Recruiter inside.",
-		recruiterWpX = 3491,
+		recruiterWaypointDesc = "Mos Eisley cantina main hall. Speak with the Mandalorian Recruiter.",
+		recruiterWpX = 3526,
 		recruiterWpZ = 5,
-		recruiterWpY = -4782,
+		recruiterWpY = -4799,
 	},
 
 	-- --------------------------------------------------------
@@ -955,11 +956,24 @@ function MandoWayOfLife:grantRecruiterWaypoint(pPlayer)
 		PlayerObject(pGhost):removeWaypoint(old, true)
 	end
 
+	local wpX = cfg.recruiterWpX
+	local wpZ = cfg.recruiterWpZ
+	local wpY = cfg.recruiterWpY
+	local recruiterOid = tonumber(readData("mando_way:recruiter_id")) or 0
+	if (recruiterOid ~= 0) then
+		local pRecruiter = getSceneObject(recruiterOid)
+		if (pRecruiter ~= nil) then
+			wpX = SceneObject(pRecruiter):getWorldPositionX()
+			wpZ = SceneObject(pRecruiter):getWorldPositionZ()
+			wpY = SceneObject(pRecruiter):getWorldPositionY()
+		end
+	end
+
 	local wpId = PlayerObject(pGhost):addWaypoint(
 		cfg.planet,
 		cfg.recruiterWaypointName or "Mandalorian Recruiter",
-		cfg.recruiterWaypointDesc or "Mos Eisley cantina. Speak with the Mandalorian Recruiter.",
-		cfg.recruiterWpX, cfg.recruiterWpZ, cfg.recruiterWpY,
+		cfg.recruiterWaypointDesc or "Mos Eisley cantina main hall. Speak with the Mandalorian Recruiter.",
+		wpX, wpZ, wpY,
 		WAYPOINT_YELLOW, true, true, 0
 	)
 	if (wpId ~= nil) then
@@ -1635,9 +1649,7 @@ function MandoWayOfLife:onPlayerLoggedIn(pPlayer)
 	end
 
 	if (not ch0) then
-		if (self:meetsPrerequisites(pPlayer)) then
-			self:grantRecruiterWaypoint(pPlayer)
-		end
+		-- Eligible players discover the recruiter organically; no datapad pin until arc_start.
 		return
 	end
 

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
@@ -2815,6 +2815,8 @@ function MandoWayOfLife:playerEligibleForMandoArmoryCatalog(pPlayer)
 	if (pPlayer == nil) then return false end
 	if (not self:isArcComplete(pPlayer)) then return false end
 	if (not CreatureObject(pPlayer):hasSkill("combat_bountyhunter_novice")) then return false end
+	-- Armory schematics unlock only after the entire Way is finished (Mandalorian Tribesman / final phase).
+	if (self:readInt(pPlayer, "chapter5Complete") ~= 1) then return false end
 	return true
 end
 
@@ -2825,15 +2827,11 @@ function MandoWayOfLife:trySellMandoArmorySchematic(pPlayer, tier)
 	if (tier == nil or type(tier) ~= "number" or tier < 1 or tier > 3) then return false, "Invalid request." end
 
 	if (not self:playerEligibleForMandoArmoryCatalog(pPlayer)) then
-		return false, "You are not cleared for the Mandalorian armory. Finish the Foundling arc and earn Novice Bounty Hunter first."
+		return false, "You are not cleared for the Mandalorian armory. Walk the entire Way and earn the Mandalorian Tribesman rank first. Then the clan armory opens to you."
 	end
 
 	local sale = self.mandoWayArmorySchematicSales[tier]
 	if (sale == nil) then return false, "Invalid request." end
-
-	if (self:readInt(pPlayer, sale.chapterFlag) ~= 1) then
-		return false, "You have not completed the trial for that rank yet. Earn the chapter first, then come back for the schematic."
-	end
 
 	local pInventory = SceneObject(pPlayer):getSlottedObject("inventory")
 	if (pInventory == nil) then return false, "I cannot reach your inventory." end

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
@@ -231,6 +231,8 @@ MandoWayOfLife = ScreenPlay:new {
 
 	-- Global writeData key prefix: one armor reissue per login account (see tryGrantAccountArmorRetro).
 	ACCOUNT_ARMOR_RETRO_DATA_PREFIX = "mando_way:acctArmorRetro:",
+	-- One title reissue per login account (see tryGrantAccountTitleRetro).
+	ACCOUNT_TITLE_RETRO_DATA_PREFIX = "mando_way:acctTitleRetro:",
 	-- Grant waypoint + coords but do not spawn a dynamic informant (use a static-placed mando_foundling_informant at planetData coords).
 	DEBUG_SKIP_INFORMANT_MOBILE_SPAWN = false,
 	-- Allow any mando_foundling_informant to advance convo while Foundling arc is active (ignores per-player OID link). Dev-only.
@@ -3010,6 +3012,138 @@ function MandoWayOfLife:tryGrantAccountArmorRetro(pPlayer)
 
 	return true,
 		"Done. Every rank armor set from Foundling through Tribesman is in your inventory — current resist tuning, one claim per login account. This is the Way."
+end
+
+-- ============================================================
+-- ACCOUNT ONE-TIME TITLE REISSUE (Recruiter convo)
+-- ============================================================
+-- Veterans who finished ranks before title skills were wired can restore equippable
+-- Community titles (mando_title_*) once per login account.
+
+function MandoWayOfLife:accountTitleRetroDataKey(pPlayer)
+	local accountId = self:getPlayerAccountId(pPlayer)
+	if (accountId == nil or accountId == 0) then return nil end
+	return self.ACCOUNT_TITLE_RETRO_DATA_PREFIX .. tostring(accountId)
+end
+
+function MandoWayOfLife:hasAccountTitleRetroClaimed(pPlayer)
+	local key = self:accountTitleRetroDataKey(pPlayer)
+	if (key == nil) then return false end
+	return (readData(key) or 0) == 1
+end
+
+-- Highest chapter this character actually earned (screenplay flags, then Mando badges).
+function MandoWayOfLife:getHighestEarnedChapter(pPlayer)
+	if (pPlayer == nil) then return -1 end
+
+	if (self:readInt(pPlayer, "chapter5Complete") == 1) then return 5 end
+	if (self:readInt(pPlayer, "chapter4Complete") == 1) then return 4 end
+	if (self:readInt(pPlayer, "chapter3Complete") == 1) then return 3 end
+	if (self:readInt(pPlayer, "chapter2Complete") == 1) then return 2 end
+	if (self:readInt(pPlayer, "chapter1Complete") == 1) then return 1 end
+	if (self:readInt(pPlayer, "chapter0Complete") == 1 or self:isArcComplete(pPlayer)) then return 0 end
+
+	local pGhost = CreatureObject(pPlayer):getPlayerObject()
+	if (pGhost ~= nil and self.chapterBadgeIds ~= nil) then
+		for ch = 5, 0, -1 do
+			local badgeId = self.chapterBadgeIds[ch]
+			if (badgeId ~= nil and PlayerObject(pGhost):hasBadge(tonumber(badgeId))) then
+				return ch
+			end
+		end
+	end
+
+	local ch = self:getChapter(pPlayer)
+	if (ch ~= nil and ch >= 0 and self:isArcComplete(pPlayer)) then
+		return ch
+	end
+
+	return -1
+end
+
+function MandoWayOfLife:countMissingChapterTitleSkills(pPlayer, maxChapter)
+	if (pPlayer == nil or maxChapter == nil or maxChapter < 0) then return 0 end
+	local missing = 0
+	local creature = CreatureObject(pPlayer)
+	for ch = 0, maxChapter do
+		local skillName = self.chapterTitleSkills[ch]
+		if (skillName ~= nil and skillName ~= "" and not creature:hasSkill(skillName)) then
+			missing = missing + 1
+		end
+	end
+	return missing
+end
+
+-- Returns ok, playerMessage
+function MandoWayOfLife:tryGrantAccountTitleRetro(pPlayer)
+	if (pPlayer == nil) then return false, "No player." end
+
+	local accountKey = self:accountTitleRetroDataKey(pPlayer)
+	if (accountKey == nil) then
+		return false, "I cannot verify your login account. Try relogging, or contact staff."
+	end
+
+	if (self:hasAccountTitleRetroClaimed(pPlayer)) then
+		return false,
+			"This account already claimed the one-time title restoration. Another character on the same login cannot claim it again."
+	end
+
+	local maxChapter = self:getHighestEarnedChapter(pPlayer)
+	if (maxChapter < 0) then
+		return false,
+			"You have not earned a Mandalorian rank on this character yet. Complete the Foundling arc first."
+	end
+
+	local missing = self:countMissingChapterTitleSkills(pPlayer, maxChapter)
+	if (missing < 1) then
+		return false,
+			"Your Community title skills already match your rank. Open Community, Character, and pick a Mandalorian title from the list."
+	end
+
+	local granted = 0
+	local creature = CreatureObject(pPlayer)
+	for ch = 0, maxChapter do
+		local skillName = self.chapterTitleSkills[ch]
+		if (skillName ~= nil and skillName ~= "" and not creature:hasSkill(skillName)) then
+			awardSkill(pPlayer, skillName)
+			if (creature:hasSkill(skillName)) then
+				granted = granted + 1
+			else
+				self:logDiagPlayer(pPlayer, string.format(
+					"tryGrantAccountTitleRetro FAILED award %s (chapter %s).",
+					skillName, tostring(ch)
+				))
+				return false,
+					"Something blocked restoring " .. skillName .. ". Contact staff before retrying."
+			end
+		end
+	end
+
+	writeData(accountKey, 1)
+	self:writeInt(pPlayer, "accountTitleRetro.claimed", 1)
+	self:writeStr(pPlayer, "accountTitleRetro.claimedAt", tostring(os.time()))
+
+	self:grantChapterRankTitle(pPlayer, maxChapter)
+
+	local capTitle = self.chapterTitles[maxChapter] or "your rank"
+	self:logDiagPlayer(pPlayer, string.format(
+		"tryGrantAccountTitleRetro OK accountId=%s maxChapter=%s granted=%s.",
+		tostring(self:getPlayerAccountId(pPlayer)),
+		tostring(maxChapter),
+		tostring(granted)
+	))
+
+	CreatureObject(pPlayer):sendSystemMessage(string.format(
+		"[Mandalorian Way] Title restoration complete: %s equippable rank title(s) through %s. Open Community — Character — Title to select one.",
+		tostring(granted),
+		capTitle
+	))
+
+	return true, string.format(
+		"Done. I restored %s equippable rank title(s) through %s. Open Community, Character, and pick a Mandalorian title from the dropdown — one claim per login account. This is the Way.",
+		tostring(granted),
+		capTitle
+	)
 end
 
 -- ============================================================


### PR DESCRIPTION
Release Patch Notes — Ender_Mando_patch
Branch: Ender_Mando_patch vs Main
Commits: 3
Deploy: Zone restart (core3 reload screenplays / conversations). No C++ rebuild required.

Mandalorian Way — Armory Schematics (Endgame Gate)
Armory schematics are now Tribesman-only.

All three Mandalorian armory loot schematics (Geo blaster, slugthrower, lightning cannon) require full questline completion — Mandalorian Tribesman (chapter5Complete), not just Foundling arc + Novice Bounty Hunter.
Finishing the Way unlocks all three schematics at once. The old per-chapter tier gate is removed.
The recruiter's static "Armory schematics" option is removed from early/mid-quest convo screens. It appears only for finished Tribesmen, injected dynamically by the handler.
Tribesmen get a new Tribesman hub screen when backing out of the armory shop.
Players who try to buy without qualifying see: "Walk the entire Way and earn the Mandalorian Tribesman rank first."
Player impact: Mid-quest Mandalorians can still earn chapter gift weapons from Spynet trials; only the recruiter schematic shop moved to endgame.

Mandalorian Way — NPC Access for Non-Initiates
Foundling informants and Spynet operatives now turn away strangers.

Players who have never started the Mandalorian arc (chapter0Started ≠ 1 and arc not complete) get a new "go away" dialog instead of silence or full access.
Both NPC types direct them to the Mandalorian Recruiter in the Mos Eisley cantina on Tatooine.
Players who already finished the arc and are past that contact are unchanged (informant stays silent as before).
Mandalorian Way — Veteran Title Restoration (Recruiter)
One-time account fix for missing rank titles in Community.

New recruiter convo option: "Restore my Way rank titles (once per account)."
Restores all missing equippable mando_title_* skills through the character's highest earned chapter (Foundling through current rank).
Uses chapter completion flags and Mando badge fallback for veterans who earned badges but never got Community dropdown entries.
One claim per login account — separate flag from the existing armor reissue (mando_way:acctTitleRetro:).
Option only appears when at least one title skill is actually missing.
On success, equips the highest restored rank and tells the player to pick a title under Community → Character → Title.
Client requirement: bg_custom1.tre must include skills.iff + skl_n rows for mando_title_* skills (existing dependency from prior Mando title work).

Mandalorian Way — Recruiter Waypoint Fixes
Recruiter datapad pin timing and placement corrected.

No recruiter waypoint on login for prerequisite-eligible players who have not yet accepted Chapter 0. The pin is granted only after startFoundlingArc at the recruiter.
grantRecruiterWaypoint() now resolves the live recruiter NPC position from mando_way:recruiter_id when the cantina recruiter is spawned.
Static fallback coords corrected from Tatooine informant hub coords (3491, -4782) to the Mos Eisley cantina block (~3526, -4799).
Waypoint description updated to "Mos Eisley cantina main hall."
Player impact: Master Bounty Hunters and other eligible players no longer get a misleading yellow pin at the wrong location before they've started the arc.