### PR TITLE
Remove full armor regrant, keep only bracer/bicep grants

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
+++ b/MMOCoreORB/bin/scripts/mobile/conversations/bellum/mando_trialmaster_conv.lua
@@ -251,28 +251,6 @@ buy_mando_armory_3 = ConvoScreen:new {
 }
 mandoTrialmasterConvoTemplate:addScreen(buy_mando_armory_3)
 
--- Recruiter-only (handler): one-time per login account reissue of all chapter armor sets.
-mando_armor_retro = ConvoScreen:new {
-	id = "mando_armor_retro",
-	leftDialog = "",
-	customDialogText = "For veterans of the Way: I can reissue every rank armor set once per login account — Foundling helmet through the full Tribesman panoply — using today's resist values. You need twenty free inventory slots. Another character on your account cannot claim this again.",
-	stopConversation = "false",
-	options = {
-		{"Grant the armor sets.", "mando_armor_retro_grant"},
-		{"Not now.", "bye"},
-	}
-}
-mandoTrialmasterConvoTemplate:addScreen(mando_armor_retro)
-
-mando_armor_retro_grant = ConvoScreen:new {
-	id = "mando_armor_retro_grant",
-	leftDialog = "",
-	customDialogText = "Processing.",
-	stopConversation = "true",
-	options = {}
-}
-mandoTrialmasterConvoTemplate:addScreen(mando_armor_retro_grant)
-
 -- Recruiter-only (handler): one-time per login account restoration of equippable rank titles.
 mando_title_retro = ConvoScreen:new {
 	id = "mando_title_retro",

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_belt.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_belt.lua
@@ -101,8 +101,8 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_belt = object_tang
 				"object/mobile/vendor/ithorian_male.iff",
 				"object/mobile/vendor/wookiee_female.iff",
 				"object/mobile/vendor/wookiee_male.iff" },
-	
 
+	socket = 4,
 }
 
 ObjectTemplates:addTemplate(object_tangible_wearables_armor_mandalorian_armor_mandalorian_belt, "object/tangible/wearables/armor/mandalorian/armor_mandalorian_belt.iff")

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bicep_l.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bicep_l.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_bicep_l = object_t
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bicep_r.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bicep_r.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_bicep_r = object_t
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bracer_l.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bracer_l.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_bracer_l = object_
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bracer_r.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_bracer_r.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_bracer_r = object_
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_chest_plate.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_chest_plate.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_chest_plate = obje
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_gloves.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_gloves.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_gloves = object_ta
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_helmet.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_helmet = object_ta
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_leggings.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_leggings.lua
@@ -113,6 +113,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_leggings = object_
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_shoes.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/armor_mandalorian_shoes.lua
@@ -116,6 +116,7 @@ object_tangible_wearables_armor_mandalorian_armor_mandalorian_shoes = object_tan
 	-- LIGHT, MEDIUM, HEAVY
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 58,
 	energy = 58,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_belt.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_belt.lua
@@ -59,6 +59,8 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_belt = object_tangi
 				"object/mobile/vendor/ithorian_male.iff",
 				"object/mobile/vendor/wookiee_female.iff",
 				"object/mobile/vendor/wookiee_male.iff" },
+
+	socket = 4,
 }
 
 ObjectTemplates:addTemplate(object_tangible_wearables_armor_mandalorian_custom_clanbound_belt, "object/tangible/wearables/armor/mandalorian/custom/clanbound_belt.iff")

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bicep_l.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bicep_l.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_bicep_l = object_ta
 
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bicep_r.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bicep_r.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_bicep_r = object_ta
 
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bracer_l.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bracer_l.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_bracer_l = object_t
 
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bracer_r.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_bracer_r.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_bracer_r = object_t
 
 	rating = LIGHT,
 	maxCondition = 40000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_chest.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_chest.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_chest = object_tang
 
 	rating = HEAVY,
 	maxCondition = 58000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_gloves.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_gloves.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_gloves = object_tan
 
 	rating = HEAVY,
 	maxCondition = 54000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_helmet.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_helmet = object_tan
 
 	rating = HEAVY,
 	maxCondition = 56000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_legs.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_legs.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_legs = object_tangi
 
 	rating = HEAVY,
 	maxCondition = 56000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_shoes.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/clanbound_shoes.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_clanbound_shoes = object_tang
 
 	rating = HEAVY,
 	maxCondition = 52000,
+	socket = 4,
 
 	kinetic = 70,
 	energy = 70,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/foundling_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/foundling_helmet.lua
@@ -71,6 +71,7 @@ object_tangible_wearables_armor_mandalorian_custom_foundling_helmet = object_tan
 	-- Design table Ch0: LIGHT — 50% all standard resists; stun and lightsaber unprotected.
 	rating = LIGHT,
 	maxCondition = 25000,
+	socket = 4,
 
 	kinetic = 50,
 	energy = 50,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/hunter_chest.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/hunter_chest.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_hunter_chest = object_tangibl
 
 	rating = LIGHT,
 	maxCondition = 36000,
+	socket = 4,
 
 	kinetic = 60,
 	energy = 60,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/hunter_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/hunter_helmet.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_hunter_helmet = object_tangib
 
 	rating = LIGHT,
 	maxCondition = 34000,
+	socket = 4,
 
 	kinetic = 60,
 	energy = 60,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/hunter_legs.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/hunter_legs.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_hunter_legs = object_tangible
 
 	rating = LIGHT,
 	maxCondition = 36000,
+	socket = 4,
 
 	kinetic = 60,
 	energy = 60,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/initiate_chest.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/initiate_chest.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_initiate_chest = object_tangi
 
 	rating = LIGHT,
 	maxCondition = 30000,
+	socket = 4,
 
 	kinetic = 55,
 	energy = 55,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/initiate_gloves.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/initiate_gloves.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_initiate_gloves = object_tang
 
 	rating = LIGHT,
 	maxCondition = 28000,
+	socket = 4,
 
 	kinetic = 55,
 	energy = 55,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/initiate_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/initiate_helmet.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_initiate_helmet = object_tang
 
 	rating = LIGHT,
 	maxCondition = 28000,
+	socket = 4,
 
 	kinetic = 55,
 	energy = 55,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_chest.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_chest.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_tribesman_chest = object_tang
 
 	rating = HEAVY,
 	maxCondition = 62000,
+	socket = 4,
 
 	kinetic = 75,
 	energy = 75,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_gloves.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_gloves.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_tribesman_gloves = object_tan
 
 	rating = HEAVY,
 	maxCondition = 58000,
+	socket = 4,
 
 	kinetic = 75,
 	energy = 75,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_helmet.lua
@@ -69,6 +69,7 @@ object_tangible_wearables_armor_mandalorian_custom_tribesman_helmet = object_tan
 
 	rating = HEAVY,
 	maxCondition = 60000,
+	socket = 4,
 
 	kinetic = 75,
 	energy = 75,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_legs.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_legs.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_tribesman_legs = object_tangi
 
 	rating = HEAVY,
 	maxCondition = 60000,
+	socket = 4,
 
 	kinetic = 75,
 	energy = 75,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_shoes.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/tribesman_shoes.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_tribesman_shoes = object_tang
 
 	rating = HEAVY,
 	maxCondition = 56000,
+	socket = 4,
 
 	kinetic = 75,
 	energy = 75,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_chest.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_chest.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_verdika_chest = object_tangib
 
 	rating = MEDIUM,
 	maxCondition = 48000,
+	socket = 4,
 
 	kinetic = 65,
 	energy = 65,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_gloves.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_gloves.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_verdika_gloves = object_tangi
 
 	rating = MEDIUM,
 	maxCondition = 42000,
+	socket = 4,
 
 	kinetic = 65,
 	energy = 65,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_helmet.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_helmet.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_verdika_helmet = object_tangi
 
 	rating = MEDIUM,
 	maxCondition = 44000,
+	socket = 4,
 
 	kinetic = 65,
 	energy = 65,

--- a/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_legs.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/wearables/armor/mandalorian/custom/verdika_legs.lua
@@ -68,6 +68,7 @@ object_tangible_wearables_armor_mandalorian_custom_verdika_legs = object_tangibl
 
 	rating = MEDIUM,
 	maxCondition = 46000,
+	socket = 4,
 
 	kinetic = 65,
 	energy = 65,

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
@@ -51,9 +51,9 @@ function MandoTrialmasterConvoHandler:withRecruiterRetroOptions(pPlayer, pNpc, p
 		added = true
 	end
 
-	if (MandoWayOfLife:isMandoTribesman(pPlayer) and not MandoWayOfLife:hasAccountBicepBracerRetroClaimed(pPlayer)) then
+	if (MandoWayOfLife:isMandoTribesman(pPlayer) and not MandoWayOfLife:hasCharacterBicepBracerRetroClaimed(pPlayer)) then
 		cloned:addOption(
-			"Claim missing Tribesman bicep and bracer armor pieces (one-time per account).",
+			"Claim missing Tribesman bicep and bracer armor pieces (one-time per character).",
 			"mando_bicep_bracer_retro"
 		)
 		added = true
@@ -234,7 +234,7 @@ function MandoTrialmasterConvoHandler:runScreenHandlers(pConvTemplate, pPlayer, 
 			cloned:setStopConversation(true)
 			return pCloned
 		end
-		local ok, msg = MandoWayOfLife:tryGrantAccountBicepBracerRetro(pPlayer)
+		local ok, msg = MandoWayOfLife:tryGrantCharacterBicepBracerRetro(pPlayer)
 		local luaScreen = LuaConversationScreen(pConvScreen)
 		local pCloned = luaScreen:cloneScreen()
 		local cloned = LuaConversationScreen(pCloned)

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
@@ -21,14 +21,6 @@ function MandoTrialmasterConvoHandler:withRecruiterRetroOptions(pPlayer, pNpc, p
 		tostring(LuaConversationScreen(pScreen):getScreenID())
 	))
 
-	if (not MandoWayOfLife:hasAccountArmorRetroClaimed(pPlayer)) then
-		cloned:addOption(
-			"Reissue all Way armor sets (once per account).",
-			"mando_armor_retro"
-		)
-		added = true
-	end
-
 	if (not MandoWayOfLife:hasAccountTitleRetroClaimed(pPlayer)) then
 		local maxChapter = MandoWayOfLife:getHighestEarnedChapter(pPlayer)
 		if (maxChapter >= 0 and MandoWayOfLife:countMissingChapterTitleSkills(pPlayer, maxChapter) > 0) then
@@ -178,24 +170,6 @@ function MandoTrialmasterConvoHandler:runScreenHandlers(pConvTemplate, pPlayer, 
 	elseif (screenID == "foundling_resync") then
 		-- Force despawn + respawn informant and re-grant waypoints for current planetIndex (stuck contact / bad OID).
 		MandoWayOfLife:resyncFoundlingContactAndWaypoints(pPlayer)
-
-	elseif (screenID == "mando_armor_retro_grant") then
-		if (not MandoWayOfLife:isMandoRecruiterNpc(pNpc)) then
-			local luaScreen = LuaConversationScreen(pConvScreen)
-			local pCloned = luaScreen:cloneScreen()
-			local cloned = LuaConversationScreen(pCloned)
-			cloned:setCustomDialogText("That reissue is handled by the Mandalorian Recruiter in the Mos Eisley cantina.")
-			cloned:setStopConversation(true)
-			return pCloned
-		end
-		local ok, msg = MandoWayOfLife:tryGrantAccountArmorRetro(pPlayer)
-		local luaScreen = LuaConversationScreen(pConvScreen)
-		local pCloned = luaScreen:cloneScreen()
-		local cloned = LuaConversationScreen(pCloned)
-		cloned:setCustomDialogText(msg)
-		cloned:setStopConversation(true)
-		MandoWayOfLife:logDiagPlayer(pPlayer, string.format("Recruiter convo: mando_armor_retro_grant ok=%s.", tostring(ok)))
-		return pCloned
 
 	elseif (screenID == "mando_title_retro_grant") then
 		if (not MandoWayOfLife:isMandoRecruiterNpc(pNpc)) then

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/convos/mando_trialmaster_conv_handler.lua
@@ -59,6 +59,17 @@ function MandoTrialmasterConvoHandler:withRecruiterRetroOptions(pPlayer, pNpc, p
 		added = true
 	end
 
+	if (MandoWayOfLife:isMandoTribesman(pPlayer)) then
+		local oldCount = MandoWayOfLife:countOldMandalorianArmor(pPlayer)
+		if (oldCount > 0) then
+			cloned:addOption(
+				"Exchange old Mandalorian armor for new custom armor.",
+				"mando_armor_exchange"
+			)
+			added = true
+		end
+	end
+
 	if (not added) then return pScreen end
 	return pCloned
 end
@@ -241,6 +252,24 @@ function MandoTrialmasterConvoHandler:runScreenHandlers(pConvTemplate, pPlayer, 
 		cloned:setCustomDialogText(msg)
 		cloned:setStopConversation(true)
 		MandoWayOfLife:logDiagPlayer(pPlayer, string.format("Recruiter convo: mando_bicep_bracer_retro ok=%s.", tostring(ok)))
+		return pCloned
+
+	elseif (screenID == "mando_armor_exchange") then
+		if (not MandoWayOfLife:isMandoRecruiterNpc(pNpc)) then
+			local luaScreen = LuaConversationScreen(pConvScreen)
+			local pCloned = luaScreen:cloneScreen()
+			local cloned = LuaConversationScreen(pCloned)
+			cloned:setCustomDialogText("That exchange is handled by the Mandalorian Recruiter in the Mos Eisley cantina.")
+			cloned:setStopConversation(true)
+			return pCloned
+		end
+		local ok, msg = MandoWayOfLife:tryExchangeMandalorianArmor(pPlayer)
+		local luaScreen = LuaConversationScreen(pConvScreen)
+		local pCloned = luaScreen:cloneScreen()
+		local cloned = LuaConversationScreen(pCloned)
+		cloned:setCustomDialogText(msg)
+		cloned:setStopConversation(true)
+		MandoWayOfLife:logDiagPlayer(pPlayer, string.format("Recruiter convo: mando_armor_exchange ok=%s.", tostring(ok)))
 		return pCloned
 
 	elseif (screenID == "buy_mando_armory_1" or screenID == "buy_mando_armory_2" or screenID == "buy_mando_armory_3") then

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
@@ -245,7 +245,7 @@ MandoWayOfLife = ScreenPlay:new {
 	-- One-time per login account grant of missing bicep and bracer pieces for Ch5 completers
 	ACCOUNT_BICEP_BRACER_RETRO_PREFIX = "mando_way:acctBicepBracerRetro:",
 	-- Daily Bounty Mission Fob IFF
-	DAILY_BOUNTY_FOB_IFF = "object/tangible/loot/quest/force_sensitive/mandalorian_mission_fob.iff",
+	DAILY_BOUNTY_FOB_IFF = "object/tangible/mission/mando_daily_bounty_fob.iff",
 	-- Maximum daily bounty missions per player
 	DAILY_BOUNTY_MAX_MISSIONS = 5,
 	-- Daily bounty mission data key prefix (per player, per day)
@@ -3042,38 +3042,26 @@ function MandoWayOfLife:tryGrantAccountArmorRetro(pPlayer)
 end
 
 -- ============================================================
--- ACCOUNT ONE-TIME BICEP AND BRACER GRANT (Recruiter convo)
+-- CHARACTER ONE-TIME BICEP AND BRACER GRANT (Recruiter convo)
 -- ============================================================
--- One-time per login account grant of missing bicep and bracer pieces for Ch5 completers
+-- One-time per character grant of missing bicep and bracer pieces for Ch5 completers
 -- who finished before these pieces were added to the reward set.
 
-function MandoWayOfLife:accountBicepBracerRetroDataKey(pPlayer)
-	local accountId = self:getPlayerAccountId(pPlayer)
-	if (accountId == nil or accountId == 0) then return nil end
-	return self.ACCOUNT_BICEP_BRACER_RETRO_PREFIX .. tostring(accountId)
+function MandoWayOfLife:hasCharacterBicepBracerRetroClaimed(pPlayer)
+	if (pPlayer == nil) then return false end
+	return self:readInt(pPlayer, "bicepBracerRetro.claimed") == 1
 end
 
-function MandoWayOfLife:hasAccountBicepBracerRetroClaimed(pPlayer)
-	local key = self:accountBicepBracerRetroDataKey(pPlayer)
-	if (key == nil) then return false end
-	return (readData(key) == 1)
-end
-
-function MandoWayOfLife:tryGrantAccountBicepBracerRetro(pPlayer)
+function MandoWayOfLife:tryGrantCharacterBicepBracerRetro(pPlayer)
 	if (pPlayer == nil) then return false, "No player." end
 
 	if (not self:isMandoTribesman(pPlayer)) then
 		return false, "Only Mandalorian Tribesmen may claim the missing armor pieces."
 	end
 
-	local accountKey = self:accountBicepBracerRetroDataKey(pPlayer)
-	if (accountKey == nil) then
-		return false, "I cannot verify your login account. Try relogging, or contact staff."
-	end
-
-	if (self:hasAccountBicepBracerRetroClaimed(pPlayer)) then
+	if (self:hasCharacterBicepBracerRetroClaimed(pPlayer)) then
 		return false,
-			"This account already claimed the one-time bicep and bracer grant. Another character on the same login cannot claim it again."
+			"This character already claimed the one-time bicep and bracer grant."
 	end
 
 	local templates = {
@@ -3107,22 +3095,21 @@ function MandoWayOfLife:tryGrantAccountBicepBracerRetro(pPlayer)
 		end
 	end
 
-	writeData(accountKey, 1)
-	self:writeInt(pPlayer, "accountBicepBracerRetro.claimed", 1)
-	self:writeStr(pPlayer, "accountBicepBracerRetro.claimedAt", tostring(os.time()))
+	self:writeInt(pPlayer, "bicepBracerRetro.claimed", 1)
+	self:writeStr(pPlayer, "bicepBracerRetro.claimedAt", tostring(os.time()))
 
 	self:logDiagPlayer(pPlayer, string.format(
-		"tryGrantAccountBicepBracerRetro OK accountId=%s pieces=%s.",
-		tostring(self:getPlayerAccountId(pPlayer)),
+		"tryGrantCharacterBicepBracerRetro OK playerOid=%s pieces=%s.",
+		tostring(SceneObject(pPlayer):getObjectID()),
 		tostring(requiredSlots)
 	))
 
 	CreatureObject(pPlayer):sendSystemMessage(
-		"[Mandalorian Way] One-time account bicep and bracer grant complete. Your Tribesman set is now complete."
+		"[Mandalorian Way] One-time character bicep and bracer grant complete. Your Tribesman set is now complete."
 	)
 
 	return true,
-		"Done. The missing bicep and bracer pieces for your Tribesman armor are in your inventory — one claim per login account. This is the Way."
+		"Done. The missing bicep and bracer pieces for your Tribesman armor are in your inventory — one claim per character. This is the Way."
 end
 
 -- ============================================================

--- a/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/bellum/mando_way_of_life.lua
@@ -244,6 +244,22 @@ MandoWayOfLife = ScreenPlay:new {
 	ACCOUNT_SCHEMATIC_EXCHANGE_PREFIX = "mando_way:acctSchematicExchange:",
 	-- One-time per login account grant of missing bicep and bracer pieces for Ch5 completers
 	ACCOUNT_BICEP_BRACER_RETRO_PREFIX = "mando_way:acctBicepBracerRetro:",
+	
+	-- Armor exchange mapping: old armor template -> new custom armor template
+	-- Available to Mandalorian Tribesmen anytime they have old armor in inventory
+	armorExchangeMap = {
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_helmet.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_helmet.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_chest_plate.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_chest.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_leggings.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_legs.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_gloves.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_gloves.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_belt.iff"] = "object/tangible/wearables/armor/mandalorian/custom/clanbound_belt.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_bicep_l.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_bicep_l.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_bicep_r.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_bicep_r.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_bracer_l.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_bracer_l.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_bracer_r.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_bracer_r.iff",
+		["object/tangible/wearables/armor/mandalorian/armor_mandalorian_shoes.iff"] = "object/tangible/wearables/armor/mandalorian/custom/tribesman_shoes.iff",
+	},
+	
 	-- Daily Bounty Mission Fob IFF
 	DAILY_BOUNTY_FOB_IFF = "object/tangible/mission/mando_daily_bounty_fob.iff",
 	-- Maximum daily bounty missions per player
@@ -3420,6 +3436,135 @@ function MandoWayOfLife:tryExchangeMandalorianSchematics(pPlayer)
 
 	return true, string.format(
 		"Done. I exchanged %s old Mandalorian armor schematic(s) for new learnable versions. Give them to a Master Armorsmith — one exchange per login account. This is the Way.",
+		tostring(exchanged)
+	)
+end
+
+-- ============================================================
+-- ARMOR EXCHANGE (old Mandalorian armor -> new custom armor)
+-- ============================================================
+-- For Mandalorian Tribesmen who have old Mandalorian armor.
+-- Exchange can be done anytime as long as the player has old armor in inventory.
+-- Requires: Chapter 5 complete (Mandalorian Tribesman), old armor in inventory (not equipped).
+-- Future: May require Beskar Segment components.
+
+-- Returns the number of old Mandalorian armor pieces in the player's top-level inventory.
+function MandoWayOfLife:countOldMandalorianArmor(pPlayer)
+	if (pPlayer == nil) then return 0 end
+
+	local pInventory = SceneObject(pPlayer):getSlottedObject("inventory")
+	if (pInventory == nil) then return 0 end
+
+	local count = 0
+	local sizeOk, size = pcall(function() return SceneObject(pInventory):getContainerObjectsSize() end)
+	if (not sizeOk or size == nil) then return 0 end
+
+	for i = 0, size - 1, 1 do
+		local pItem = SceneObject(pInventory):getContainerObject(i)
+		if (pItem ~= nil) then
+			local templateOk, tmpl = pcall(function() return SceneObject(pItem):getTemplateObjectPath() end)
+			if (templateOk and tmpl ~= nil and self.armorExchangeMap[tmpl] ~= nil) then
+				count = count + 1
+			end
+		end
+	end
+
+	return count
+end
+
+-- Returns an array of object pointers for old Mandalorian armor in top-level inventory.
+function MandoWayOfLife:getOldMandalorianArmorObjects(pPlayer)
+	if (pPlayer == nil) then return {} end
+
+	local pInventory = SceneObject(pPlayer):getSlottedObject("inventory")
+	if (pInventory == nil) then return {} end
+
+	local found = {}
+	local sizeOk, size = pcall(function() return SceneObject(pInventory):getContainerObjectsSize() end)
+	if (not sizeOk or size == nil) then return found end
+
+	for i = 0, size - 1, 1 do
+		local pItem = SceneObject(pInventory):getContainerObject(i)
+		if (pItem ~= nil) then
+			local templateOk, tmpl = pcall(function() return SceneObject(pItem):getTemplateObjectPath() end)
+			if (templateOk and tmpl ~= nil and self.armorExchangeMap[tmpl] ~= nil) then
+				found[#found + 1] = pItem
+			end
+		end
+	end
+
+	return found
+end
+
+-- Returns ok, playerMessage
+function MandoWayOfLife:tryExchangeMandalorianArmor(pPlayer)
+	if (pPlayer == nil) then return false, "No player." end
+
+	-- Gate: Must have completed the entire Mandalorian Way quest line (chapter 5)
+	if (not self:isMandoTribesman(pPlayer)) then
+		return false,
+			"You must complete the entire Mandalorian Way quest line (become a Mandalorian Tribesman) before exchanging armor. This is the Way."
+	end
+
+	local oldArmor = self:getOldMandalorianArmorObjects(pPlayer)
+	if (#oldArmor < 1) then
+		return false,
+			"You have no old Mandalorian armor in your inventory. Place the old armor pieces you wish to exchange in your inventory."
+	end
+
+	local pInventory = SceneObject(pPlayer):getSlottedObject("inventory")
+	if (pInventory == nil) then
+		return false, "I cannot reach your inventory."
+	end
+
+	-- Check that none of the old armor is equipped
+	for _, pOldArmor in ipairs(oldArmor) do
+		if (SceneObject(pOldArmor):isEquipped()) then
+			return false,
+				"You must unequip all old Mandalorian armor before exchanging it. Remove it from your character and place it in your inventory."
+		end
+	end
+
+	local exchanged = 0
+	for _, pOldArmor in ipairs(oldArmor) do
+		local templateOk, oldTmpl = pcall(function() return SceneObject(pOldArmor):getTemplateObjectPath() end)
+		if (templateOk and oldTmpl ~= nil) then
+			local newTmpl = self.armorExchangeMap[oldTmpl]
+			if (newTmpl ~= nil) then
+				-- Create new custom armor
+				local pNewArmor = giveItem(pInventory, newTmpl, -1)
+				if (pNewArmor ~= nil) then
+					-- Destroy old armor
+					SceneObject(pOldArmor):destroyObjectFromWorld(true)
+					SceneObject(pOldArmor):destroyObjectFromDatabase(true)
+					exchanged = exchanged + 1
+				else
+					self:logDiagPlayer(pPlayer, string.format(
+						"tryExchangeMandalorianArmor FAILED giveItem for %s.",
+						newTmpl
+					))
+				end
+			end
+		end
+	end
+
+	if (exchanged < 1) then
+		return false, "Something blocked the exchange. Contact staff."
+	end
+
+	self:logDiagPlayer(pPlayer, string.format(
+		"tryExchangeMandalorianArmor OK playerOid=%s exchanged=%s.",
+		tostring(SceneObject(pPlayer):getObjectID()),
+		tostring(exchanged)
+	))
+
+	CreatureObject(pPlayer):sendSystemMessage(string.format(
+		"[Mandalorian Way] Armor exchange complete: %s old Mandalorian armor piece(s) exchanged for new custom armor. This is the Way!",
+		tostring(exchanged)
+	))
+
+	return true, string.format(
+		"Done. I exchanged %s old Mandalorian armor piece(s) for new custom armor. Your old armor has been destroyed. You may exchange more armor anytime. This is the Way.",
 		tostring(exchanged)
 	)
 end


### PR DESCRIPTION
- Removed one-time account armor regrant option that lacked completion gate
- Players could get all armor sets without completing questline
- Kept bicep/bracer retro grant which has proper isMandoTribesman check
- Fixes issue where new players could access full armor sets early